### PR TITLE
Fixes to build on Linux (64-bit Arch Linux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/dev/src/*.o
+/dev/**/*.o
+/dev/src/lobster
 *.suo
 *.lbc
 

--- a/dev/src/Makefile
+++ b/dev/src/Makefile
@@ -1,8 +1,10 @@
 CXXFLAGS= -O3 -fomit-frame-pointer
 override CXXFLAGS+= -m32 --std=c++0x -Wall -Wno-multichar -Wno-reorder -Wno-delete-non-virtual-dtor -DNDEBUG
+CFLAGS= -O3 -fomit-frame-pointer
+override CFLAGS+= -m32 -Wall -DNDEBUG
 
-INCLUDES= `freetype-config --cflags` `sdl2-config --cflags` -I.
-LIBS= `freetype-config --libs` `sdl2-config --libs` -lGL
+INCLUDES= `freetype-config --cflags` `sdl2-config --cflags` -I. -I../include
+LIBS= -L/usr/lib32 `freetype-config --libs` `sdl2-config --libs` -lGL
 
 OBJS= \
 	audio.o \
@@ -20,12 +22,15 @@ OBJS= \
 	lobsterreader.o \
 	meshgen.o \
 	platform.o \
+	physics.o \
 	sdlaudiosfxr.o \
 	sdlsystem.o \
 	simplex.o \
 	stdafx.o \
 	vmdata.o \
 	../lib/stb_image.o
+
+OBJS += $(patsubst %.cpp,%.o,$(shell find ../include/Box2D -name "*.cpp"))
 
 $(OBJS): CXXFLAGS += $(INCLUDES)
 

--- a/dev/src/platform.cpp
+++ b/dev/src/platform.cpp
@@ -15,6 +15,7 @@
 // misc platform specific stuff
 
 #include "stdafx.h"
+#include <stdarg.h>
 
 #ifdef WIN32
     #define VC_EXTRALEAN

--- a/dev/src/sdlsystem.cpp
+++ b/dev/src/sdlsystem.cpp
@@ -257,7 +257,7 @@ string SDLInit(const char *title, int2 &screensize, bool fullscreen)
     //certain older Intel HD GPUs and also Nvidia Quadro 1000M don't support 3.1 ? the 1000M is supposed to support 4.2
     //SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     //SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
-    #ifndef WIN32
+    #ifdef __APPLE__
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
     #endif


### PR DESCRIPTION
This compiles and runs successfully on my machine. I'm not sure how to make it more portable - you can see I hard-coded the `/usr/lib32` path which I think only exists on an amd64 multilib setup.

This will also statically link in Box2D from the include folder, since I didn't have a package for a 32-bit version of the library. But based on the README comment about Box2D combining src and include, maybe static linking is the norm for this library?
