### PR TITLE
Fix cofor so the samples run again

### DIFF
--- a/lobster/include/std.lobster
+++ b/lobster/include/std.lobster
@@ -135,7 +135,7 @@ function coroutine_for(co, f):
 
 // builtin for() made useful as a coroutine.
 function cofor(n, f):
-    for(n): f(i)
+    for(n): f(_)
     n
 
 // error checking


### PR DESCRIPTION
The implementation of cofor has an i (unbound variable name) where it should probably have a _. That should be the only change that I put in this PR.