### PR TITLE
Some fixes for the gcc build

### DIFF
--- a/dev/src/meshgen.cpp
+++ b/dev/src/meshgen.cpp
@@ -199,7 +199,7 @@ template<typename T> class RLE3DGrid
         else if (it_z + it[0].count - 1 == pos.z())
         {
             // Similarly, if this is the last value of the range..
-            if (it_z + it[0].count < dim.z() && it[3].val == newval)
+            if (dim.z() > it_z + it[0].count && it[3].val == newval)
             {
                 // ..and the next range has the new value, we can also shift these ranges.
                 it[2].count++;

--- a/dev/src/stdafx.h
+++ b/dev/src/stdafx.h
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <float.h>
+#include <limits.h>
 
 #include <string>
 #include <map>


### PR DESCRIPTION
* INT_{MIN,MAX} are defined in limits.h
* workaround a nasty template parsing bug in g++:
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10200