### PR TITLE
Fixes main dir issue on linux.

### DIFF
--- a/dev/src/platform.cpp
+++ b/dev/src/platform.cpp
@@ -34,6 +34,10 @@
     #define FILESEP '/'
 #endif
 
+#ifdef __linux__
+    #include <unistd.h>
+#endif
+
 #ifdef __APPLE__
 #include "CoreFoundation/CoreFoundation.h"
 #ifndef __IOS__
@@ -151,6 +155,14 @@ string GetMainDirFromExePath(const char *argv_0) {
         char winfn[MAX_PATH + 1];
         GetModuleFileName(NULL, winfn, MAX_PATH + 1);
         md = winfn;
+    #endif
+    #ifdef __linux__
+        char path[PATH_MAX];
+        ssize_t length = readlink("/proc/self/exe", path, sizeof(path)-1);
+        if (length != -1) {
+          path[length] = '\0';
+          md = string(path);
+        }
     #endif
     md = StripTrailing(StripTrailing(StripFilePart(md), "bin/"), "bin\\");
     return md;


### PR DESCRIPTION
Currently if you make a symlink to lobster in one of your path dirs, or just move lobster's folder into your path it will not be able to find your modules folder.  

This is the Linux equivalent of https://github.com/aardappel/lobster/issues/42