### PR TITLE
Fix for mouse trapping issue on Linux. Issue #26

### DIFF
--- a/dev/src/sdlsystem.cpp
+++ b/dev/src/sdlsystem.cpp
@@ -620,10 +620,7 @@ bool SDLCursor(bool on) {
         } else {
             if (fullscreen) SDL_SetWindowGrab(_sdl_window, SDL_TRUE);
             SDL_ShowCursor(0);
-            #if defined(_WIN32) || defined(__APPLE__)
-            // This is broken on Linux, gives bogus xrel/yrel in SDL_MOUSEMOVE
             SDL_SetRelativeMouseMode(SDL_TRUE);
-            #endif
             clearfingers(false);
         }
     }
@@ -681,4 +678,3 @@ int SDLScreenDPI(int screen) {
            ? 0  // Screen not present.
            : (int)(ddpi + 0.5f);
 }
-


### PR DESCRIPTION
Removes if def for SDL_SetRelativeMouseMode as issue is no longer reproducible with SDL 2.0.9.
I can not reproduce bad numbers coming from SDL_MOUSEMOVE xrel/yrel.   First person shooter camera from iqmtest works fine as does gl_mouse_pos(0) works as expected  with or without gl_grab.   
