### PR TITLE
Ignore crash logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ dev/android-project/.gradle
 dev/android-project/.idea
 dev/android-project/app/build
 dev/android-project/app/src/main/assets/default.lpak
+
+*.exp.log


### PR DESCRIPTION
I ended up with a `bin\lobster.exe.exp.log` crash log, so let's git ignore it?