### PR TITLE
std.lobster: rework randomize to use fisher-yates

### DIFF
--- a/modules/std.lobster
+++ b/modules/std.lobster
@@ -152,8 +152,11 @@ def insert_ordered(xs, x, lt):
     xs.push(x)
 
 def randomize(xs):
-    // Simple and effective, but remove makes it expensive.
-    for(xs.length) i: xs.push(xs.remove(rnd(xs.length - i)))
+    for(xs) x, i:
+        if i:
+            let j = rnd(i + 1)
+            xs[i] = xs[j]
+            xs[j] = x
     return xs
 
 def nest_if(c, nest, with):


### PR DESCRIPTION
This uses (one of the possible) interpretations of the [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher–Yates_shuffle), which is still fair, but does less array scanning than the push/remove prior.

I left in a `FIXME` note about how it'd be nice to have typical Pythonic (other languages like Go have also these days) multi-assign syntax.