### PR TITLE
Sorting Things Out

### DIFF
--- a/tests/sorttest.lobster
+++ b/tests/sorttest.lobster
@@ -1,0 +1,33 @@
+import std
+
+// FIXME why is the `0` literal typed
+def sumf(xs): return fold(xs, 0.0): _x + _y
+
+def timeit(budget, limit, body):
+    var times = []::float
+    while times.length() < limit and times.sumf() < budget:
+        let n = if times.length() == 0:
+            1
+        else:
+            let total = times.sumf()
+            let avg = total / times.length()
+            let rem = budget - total
+            min(limit, max(1, int(rem / 2 / avg)))
+        let more = map(n):
+            let t0 = seconds_elapsed()
+            body()
+            let t1 = seconds_elapsed()
+            t1 - t0
+        times = append(times, more)
+    return times from timeit
+
+for([10, 100, 200, 400, 1000]) N:
+    var xs = map(N): _
+    let times = timeit(1.0, 100000):
+        var ys = copy(xs)
+        ys.randomize()
+        ys.qsort_in_place(): _a < _b
+        assert equal(xs, ys)
+    let total = times.sumf()
+    let avg = total / times.length()
+    print "N:" + N + "\tops:" + times.length() + "\ts/op:" + avg


### PR DESCRIPTION
Example results on my machine before the change to use insertion sort:

```
N:10    ops:6457        s/op:0.000154881044
N:100   ops:381 s/op:0.002627428871
N:200   ops:165 s/op:0.006089478788
N:400   ops:74  s/op:0.013641381081
N:1000  ops:25  s/op:0.04020962
```

However what's really prompting me to toss this into an early draft PR, is this mysterious error:
```
std.lobster(129): VM error: VM internal assertion failure: C:\Users\jcorb\lobster\dev\src\vm.cpp: 402: sp == stf.spstart
   stack: 0xa
in function: rec -> std.lobster(129)
   l = 10
   e = 10
   s = 0
in function: qsort_in_place -> std.lobster(146)
   lt = <FUNCTION>
   xs = [8, 6, 7, 9, 5, 1, 4, 2, 0, 3]
in function: function114body -> sorttest.lobster(29)
   ys = [8, 6, 7, 9, 5, 1, 4, 2, 0, 3]
in function: function111fun -> sorttest.lobster(18)
   t0 = 0.0360891
in function: map -> std.lobster(6)
   i = 0
   x = 0
   r = []
   fun = <FUNCTION>
   xs = 1
in function: timeit -> sorttest.lobster(16)
   n = 1
   times = []
   body = <FUNCTION>
   limit = 100000
   budget = 1.0
in function: __top_level_expression -> sorttest.lobster(26)
   xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
   N = 10
```

Also do note the typed-0 weirdness regarding `sum`.