### PR TITLE
texture: use clear color in render_to_texture

### DIFF
--- a/modules/texture.lobster
+++ b/modules/texture.lobster
@@ -52,7 +52,7 @@ def loadtexturecached(name): return loadtexturecached(name, texture_format_none)
 // Depth texture automatically created if depth is true and depthtex is nil.
 def render_to_texture(tex, size, depth, depthtex, texture_format, f):
     if !tex || gl_texture_size(tex) != size:
-        tex = gl_create_blank_texture(size, color_black, texture_format)
+        tex = gl_create_blank_texture(size, color_clear, texture_format)
     assert tex  // FIXME
     assert gl_switch_to_framebuffer(tex, depth, texture_format, nil, depthtex)
     f()


### PR DESCRIPTION
This makes it easier to generate partially transparent textures, e.g. for a sprite sheet that aren't all solid squares.