### PR TITLE
Get commit hash and date from git in CMake, use in main.cpp

### DIFF
--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -9,6 +9,15 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/..)
 endif()
 
+# git commit date and commit hash into a definition
+execute_process(
+  COMMAND git log -1 --pretty="%cI|%h"
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_COMMIT_INFO
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+add_definitions("-DGIT_COMMIT_INFOSTR=${GIT_COMMIT_INFO}")
+
 if(LOBSTER_ENGINE)
   file(GLOB LOBSTER_SRCS
     "src/lobster/*.h"

--- a/dev/src/main.cpp
+++ b/dev/src/main.cpp
@@ -30,6 +30,10 @@
     #include "lobster/sdlinterface.h"
 #endif
 
+#ifndef GIT_COMMIT_INFOSTR
+#define GIT_COMMIT_INFOSTR __DATE__ "|unknown"
+#endif
+
 using namespace lobster;
 
 void unit_test_all(bool full) {
@@ -166,8 +170,9 @@ int main(int argc, char* argv[]) {
 
         if (!fn) {
             if (!LoadPakDir(default_lpak))
-                THROW_OR_ABORT("Lobster programming language compiler/runtime (version " __DATE__
-                               ")\nno arguments given - cannot load " + (default_lpak + helptext));
+                THROW_OR_ABORT("Lobster programming language compiler/runtime (version "
+                               GIT_COMMIT_INFOSTR ")\nno arguments given - cannot load " 
+                               + (default_lpak + helptext));
             // This will now come from the pakfile.
             if (!LoadByteCode(vmargs.bytecode_buffer))
                 THROW_OR_ABORT(string("Cannot load bytecode from pakfile!"));


### PR DESCRIPTION
This commit fixes #86 for CMake by getting commit hash in CMake and providing to `main.cpp` via a preprocessor macro `GIT_COMMIT_INFOSTR` 

It's does not yet address the issue in the other build systems. I looked at XCode, and I'm not sure if the preprocessor macro mechanism will work without a non-versioned include or .xcconfig file.