### PR TITLE
Add builtin gl_pressedkeys

### DIFF
--- a/dev/src/graphics.cpp
+++ b/dev/src/graphics.cpp
@@ -247,6 +247,17 @@ nfr("gl_button", "name", "S", "I",
         return Value(ks.Step());
     });
 
+nfr("gl_pressedkeys", "", "", "S]",
+    "returns the names of the keys currently pressed.",
+    [](StackPtr &sp, VM &vm) {
+        auto klist = (LVector *)vm.NewVec(0, 0, TYPE_ELEM_VECTOR_OF_STRING);
+        auto pkset = GetKeyPressInfo();
+        set<string>::iterator iter;
+        for (iter = pkset.begin(); iter != pkset.end(); ++iter)
+            klist->Push(vm, Value(vm.NewString(*iter))); // cout << *iter << " ";
+        return Value(klist);
+    });
+
 nfr("gl_touchscreen", "", "", "B",
     "wether a you\'re getting input from a touch screen (as opposed to mouse & keyboard)",
     [](StackPtr &, VM &) {

--- a/dev/src/lobster/sdlinterface.h
+++ b/dev/src/lobster/sdlinterface.h
@@ -31,6 +31,7 @@ extern const int2 &GetFinger(int i, bool delta);
 extern TimeBool8 GetKS(string_view name);
 extern double GetKeyTime(string_view name, int on);
 extern int2 GetKeyPos(string_view name, int on);
+extern set<string> &GetKeyPressInfo();
 extern float GetJoyAxis(int i);
 extern string &GetDroppedFile();
 


### PR DESCRIPTION
This new builtin `gl_pressedkeys` returns a `[string]` of all currently pressed keys (SDL names) such as. ["a", "left shift", "space"], making it easier to implement a text input functionality in Lobster (rather than in the SDL core code).

Also, this trivially provides the functionality for "Press any key to continue" by evaluating `gl_pressedkeys().length`

Here is a simple code showing some crudely functioning text editing using this:
```// simple graphics demo showing text input

import vec
import color

fatal(gl_window("Input Test", 640, 480))
check(gl_set_font_name("data/fonts/Inconsolata/Inconsolata-Regular.ttf") and gl_set_font_size(32), "can\'t load font!")

var text = ""   
let text_maxlength = 30
var msg = text
var last_time = gl_time()
var key = ""
var last_key = ""
let repeat_rate = 0.2

def string_find(s:string, pat:string) -> int: // slow brute force
    let N:int = s.length
    let M:int = pat.length
    for (N - M + 1) i:
        for (M) j:
            if substring(s, i+j, 1) != substring(pat, j, 1): // no match -> abort
                break
            elif j == M - 1: // still matching at last loop cycle? -> match
                return i // return position
    return -1 // no match

def inputtotext():
    let this_time = gl_time()
    let inputs = gl_pressedkeys()
    if inputs.length:
        let shift_pressed = 1 + find(inputs) i: string_find(i, "shift") >= 0 // 1 + so that 0 means false
        let backspace_pressed = 1 + find(inputs) i: i == "backspace"
        key = ""
        if not backspace_pressed:
            if text.length <= text_maxlength:
                for (inputs) i:
                    if i.length == 1:
                        if i != last_key or this_time - last_time > repeat_rate:
                            key, last_key = i, i
                        break
                    elif i == "space":
                        if last_key != " " or this_time - last_time > repeat_rate:
                            key, last_key = " ", " "
                        break
                if key.length:
                    if shift_pressed:
                        switch key:
                            case "`": text += "~"
                            case "1": text += "!"
                            case "2": text += "@"
                            case "3": text += "#"
                            case "4": text += "$"
                            case "5": text += "%"
                            case "6": text += "^"
                            case "7": text += "&"
                            case "8": text += "*"
                            case "9": text += "("
                            case "0": text += ")"
                            case "-": text += "_"
                            case "=": text += "+"
                            case "[": text += "{"
                            case "]": text += "}"
                            case "\\": text += "|" // " // this double comment exists to not upset the editor
                            case ";": text += ":"
                            case "\'": text += "\"" // "// this double comment exists to not upset the editor
                            case ",": text += "<"
                            case ".": text += ">"
                            case "/": text += "?"
                            default: text += uppercase(key)
                    else:
                        text += key
                    last_time = gl_time()
        // backspace
        elif text.length > 0 and this_time - last_time > repeat_rate/2:
            text = substring(text, 0, text.length-1)
            last_time = gl_time()
        //print text // debug
        

while gl_frame():
    if gl_button("escape") == 1: return
    gl_clear(color_black)
    gl_set_font_size(32)
    inputtotext()
    if text.length <= text_maxlength:
        msg = text
    else:
        msg = "Too long (shorten with `backspace`)"
    gl_translate float(gl_window_size() - gl_text_size(msg)) / 2:
        gl_text(msg)
```