### PR TITLE
Extend the builtin `string_to_int` to support different bases, enabling conversion of hexadecimal const strings

### DIFF
--- a/dev/src/builtins.cpp
+++ b/dev/src/builtins.cpp
@@ -354,7 +354,7 @@ nfr("substring", "s,start,size", "SII", "S",
         return Value(ns);
     });
 
-nfr("string_to_int", "s", "SI?", "IB",
+nfr("string_to_int", "s,base", "SI?", "IB",
     "converts a string to an int given the base (2..36, e.g. 16 for hex, default is 10)."
     "returns 0 if no numeric data could be parsed; second return value is true if all"
     "characters of the string were parsed.",

--- a/dev/src/builtins.cpp
+++ b/dev/src/builtins.cpp
@@ -354,13 +354,17 @@ nfr("substring", "s,start,size", "SII", "S",
         return Value(ns);
     });
 
-nfr("string_to_int", "s", "S", "IB",
-    "converts a string to an int. returns 0 if no numeric data could be parsed."
-    "second return value is true if all characters of the string were parsed",
-    [](StackPtr &sp, VM &, Value &s) {
+nfr("string_to_int", "s", "SI?", "IB",
+    "converts a string to an int given the base (2..36, e.g. 16 for hex, default is 10)."
+    "returns 0 if no numeric data could be parsed; second return value is true if all"
+    "characters of the string were parsed.",
+    [](StackPtr &sp, VM &vm, Value &s, Value &b) {
+        int base = b.True() ? b.ival() : 10;
+        if (base < 2 || base > 36)
+            vm.BuiltinError(sp, "string_to_int: values out of range");
         char *end;
         auto sv = s.sval()->strv();
-        auto i = parse_int<iint>(sv, 10, &end);
+        auto i = parse_int<iint>(sv, base, &end);
         Push(sp,  i);
         return Value(end == sv.data() + sv.size());
     });


### PR DESCRIPTION
Simple extension of `string_to_int(s:string, base:int) -> int, int` to support bases other than 10. This complements the already existing support for this in `number_to_string` and is very useful to convert string constants read from an external source (html color tables etc.) The base parameter is optional and defaults to 10, so no existing code will break.

Old:
`print string_to_int("0xffff")` prints `0`.

Now:
`print string_to_int("0xffff", 16)` prints `65535`.

