### PR TITLE
Added new sound_channels builtin

### DIFF
--- a/dev/src/audio.cpp
+++ b/dev/src/audio.cpp
@@ -27,7 +27,7 @@ nfr("play_wav", "filename,loops,prio", "SI?I?", "I",
     " will automatically be converted on first load). the default volume is the max volume (1.0)"
     " loops is the number of repeats to play (-1 repeats endlessly, omit for no repeats)."
     " prio is the priority of the sound which determines whether it can be deleted or not"
-    " in case of too many play function calls."
+    " in case of too many play function calls (defaults to 0)"
     " returns the assigned channel number (1..8) or 0 on error",
     [](StackPtr &, VM &, Value &ins, Value &loops, Value &prio) {
         int ch = SDLPlaySound(ins.sval()->strv(), false, 1.0, loops.intval(), prio.intval());
@@ -39,17 +39,10 @@ nfr("play_sfxr", "filename,loops,prio", "SI?I?", "I",
     " to generate these). the default volume is the max volume (1.0)"
     " loops is the number of repeats to play (-1 repeats endlessly, omit for no repeats)."
     " prio is the priority of the sound which determines whether it can be deleted or not"
-    " in case of too many play function calls."
+    " in case of too many play function calls (defaults to 0)"
     " returns the assigned channel number (1..8) or 0 on error",
     [](StackPtr &, VM &, Value &ins, Value &loops, Value &prio) {
         int ch = SDLPlaySound(ins.sval()->strv(), true, 1.0, loops.intval(), prio.intval());
-        return Value(ch);
-    });
-
-nfr("sound_channels", "", "", "I",
-    "returns the number of currently available sound channels.",
-    [](StackPtr &, VM &) {
-        int ch = SDLAvailChannels();
         return Value(ch);
     });
 

--- a/dev/src/audio.cpp
+++ b/dev/src/audio.cpp
@@ -42,6 +42,13 @@ nfr("play_sfxr", "filename,loops", "SI?", "I",
         return Value(ch);
     });
 
+nfr("sound_channels", "", "", "I",
+    "returns the number of currently available sound channels.",
+    [](StackPtr &, VM &) {
+        int ch = SDLAvailChannels();
+        return Value(ch);
+    });
+
 nfr("sound_halt", "channel", "I", "",
     "terminates a specific sound channel.",
     [](StackPtr &, VM &, Value &ch) {

--- a/dev/src/audio.cpp
+++ b/dev/src/audio.cpp
@@ -22,23 +22,27 @@ using namespace lobster;
 
 void AddSound(NativeRegistry &nfr) {
 
-nfr("play_wav", "filename,loops", "SI?", "I",
+nfr("play_wav", "filename,loops,prio", "SI?I?", "I",
     "plays a sound defined by a wav file (RAW or MS-ADPCM, any bitrate other than 22050hz 16bit"
     " will automatically be converted on first load). the default volume is the max volume (1.0)"
     " loops is the number of repeats to play (-1 repeats endlessly, omit for no repeats)."
+    " prio is the priority of the sound which determines whether it can be deleted or not"
+    " in case of too many play function calls."
     " returns the assigned channel number (1..8) or 0 on error",
-    [](StackPtr &, VM &, Value &ins, Value &loops) {
-        int ch = SDLPlaySound(ins.sval()->strv(), false, 1.0, loops.intval());
+    [](StackPtr &, VM &, Value &ins, Value &loops, Value &prio) {
+        int ch = SDLPlaySound(ins.sval()->strv(), false, 1.0, loops.intval(), prio.intval());
         return Value(ch);
     });
 
-nfr("play_sfxr", "filename,loops", "SI?", "I",
+nfr("play_sfxr", "filename,loops,prio", "SI?I?", "I",
     "plays a synth sound defined by a .sfs file (use http://www.drpetter.se/project_sfxr.html"
     " to generate these). the default volume is the max volume (1.0)"
     " loops is the number of repeats to play (-1 repeats endlessly, omit for no repeats)."
+    " prio is the priority of the sound which determines whether it can be deleted or not"
+    " in case of too many play function calls."
     " returns the assigned channel number (1..8) or 0 on error",
-    [](StackPtr &, VM &, Value &ins, Value &loops) {
-        int ch = SDLPlaySound(ins.sval()->strv(), true, 1.0, loops.intval());
+    [](StackPtr &, VM &, Value &ins, Value &loops, Value &prio) {
+        int ch = SDLPlaySound(ins.sval()->strv(), true, 1.0, loops.intval(), prio.intval());
         return Value(ch);
     });
 

--- a/dev/src/audio.cpp
+++ b/dev/src/audio.cpp
@@ -53,11 +53,23 @@ nfr("sound_channels", "", "", "I",
         return Value(ch);
     });
 
+nfr("sound_status", "channel", "I", "I",
+    "provides the status of the specified sound channel."
+    " returns -1 on error or if the channel does not exist, 0 if the channel is free,"
+    " 1 if it is playing, and 2 if the channel is active but paused.",
+    [](StackPtr &, VM &, Value &ch) {
+        int ch_idx = ch.intval();
+        if (ch_idx > 0) // we disallow 0 (which would then be -1; all channels in SDL_Mixer) because it is our error value!
+            return Value(SDLSoundStatus(ch_idx));
+        else
+            return Value(-1);
+    });
+
 nfr("sound_halt", "channel", "I", "",
     "terminates a specific sound channel.",
     [](StackPtr &, VM &, Value &ch) {
         int ch_idx = ch.intval();
-        if (ch_idx > 0) // we disallow 0 (which would then be -1; all channels in SDL_Mixer) because it is our error value!
+        if (ch_idx > 0)
             SDLHaltSound(ch_idx);
         return Value();
     });

--- a/dev/src/lobster/sdlinterface.h
+++ b/dev/src/lobster/sdlinterface.h
@@ -47,7 +47,7 @@ extern bool SDLGrab(bool on);
 
 extern void SDLMessageBox(string_view title, string_view msg);
 
-extern int SDLPlaySound(string_view filename, bool sfxr, float vol, int loops);
+extern int SDLPlaySound(string_view filename, bool sfxr, float vol, int loops, int prio);
 extern void SDLSoundClose();
 extern void SDLHaltSound(int ch);
 extern void SDLPauseSound(int ch);

--- a/dev/src/lobster/sdlinterface.h
+++ b/dev/src/lobster/sdlinterface.h
@@ -47,13 +47,12 @@ extern bool SDLGrab(bool on);
 
 extern void SDLMessageBox(string_view title, string_view msg);
 
-extern int SDLPlaySound(string_view filename, bool sfxr, float vol, int loops, int prio);
+extern int SDLPlaySound(string_view filename, bool sfxr, float vol, int loops, int pri);
 extern void SDLHaltSound(int ch);
 extern void SDLPauseSound(int ch);
 extern void SDLResumeSound(int ch);
 extern void SDLSetVolume(int ch, float vol);
 extern int SDLSoundStatus(int ch);
-extern int SDLAvailChannels();
 extern void SDLSoundClose();
 
 extern int64_t SDLLoadFile(string_view absfilename, string *dest, int64_t start, int64_t len);

--- a/dev/src/lobster/sdlinterface.h
+++ b/dev/src/lobster/sdlinterface.h
@@ -48,14 +48,14 @@ extern bool SDLGrab(bool on);
 extern void SDLMessageBox(string_view title, string_view msg);
 
 extern int SDLPlaySound(string_view filename, bool sfxr, float vol, int loops, int prio);
-extern void SDLSoundClose();
 extern void SDLHaltSound(int ch);
 extern void SDLPauseSound(int ch);
-extern int SDLIsPausedSound(int ch);
 extern void SDLResumeSound(int ch);
 extern void SDLSetVolume(int ch, float vol);
+extern int SDLSoundStatus(int ch);
 extern int SDLAvailChannels();
-    
+extern void SDLSoundClose();
+
 extern int64_t SDLLoadFile(string_view absfilename, string *dest, int64_t start, int64_t len);
 
 extern bool ScreenShot(string_view filename);

--- a/dev/src/lobster/sdlinterface.h
+++ b/dev/src/lobster/sdlinterface.h
@@ -48,13 +48,14 @@ extern bool SDLGrab(bool on);
 extern void SDLMessageBox(string_view title, string_view msg);
 
 extern int SDLPlaySound(string_view filename, bool sfxr, float vol, int loops);
+extern void SDLSoundClose();
 extern void SDLHaltSound(int ch);
 extern void SDLPauseSound(int ch);
 extern int SDLIsPausedSound(int ch);
 extern void SDLResumeSound(int ch);
 extern void SDLSetVolume(int ch, float vol);
-extern void SDLSoundClose();
-
+extern int SDLAvailChannels();
+    
 extern int64_t SDLLoadFile(string_view absfilename, string *dest, int64_t start, int64_t len);
 
 extern bool ScreenShot(string_view filename);

--- a/dev/src/sdlaudiosfxr.cpp
+++ b/dev/src/sdlaudiosfxr.cpp
@@ -461,20 +461,22 @@ void SDLPauseSound(int ch) {
     Mix_Pause(ch - 1);
 }
 
-int SDLIsPausedSound(int ch) {
-    return Mix_Paused(ch - 1) > 0;
+int SDLSoundStatus(int ch) { // returns -1 for illegal channel index, 0 for available , 1 for playing, 2 for paused
+    int num_chn = Mix_AllocateChannels(-1); // called with -1 this returns the current number of channels
+    if (ch <= num_chn) return Mix_Playing(ch - 1) + Mix_Paused(ch - 1);
+    else return -1;
 }
 
 void SDLResumeSound(int ch) {
-    if (SDLIsPausedSound(ch)) Mix_Resume(ch - 1); // this already tests for SDLSoundInit() etc.
+    if (Mix_Paused(ch - 1) > 0) Mix_Resume(ch - 1); // this already tests for SDLSoundInit() etc.
 }
 
 void SDLSetVolume(int ch, float vol) {
     Mix_Volume(ch - 1, (int)(MIX_MAX_VOLUME * vol));
 }
 
-int SDLAvailChannels() {
-    int num_chn = Mix_AllocateChannels(-1); // called with -1 this returns the current number of channels
+int SDLAvailChannels() { // returns the number of available channels
+    int num_chn = Mix_AllocateChannels(-1);
     int num_avail = num_chn;
     for(int i = 0; i < num_chn; i++) {
         if (Mix_Playing(i) > 0) num_avail--;

--- a/dev/src/sdlaudiosfxr.cpp
+++ b/dev/src/sdlaudiosfxr.cpp
@@ -454,3 +454,12 @@ void SDLResumeSound(int ch) {
 void SDLSetVolume(int ch, float vol) {
     Mix_Volume(ch - 1, (int)(MIX_MAX_VOLUME * vol));
 }
+
+int SDLAvailChannels() {
+    int num_chn = Mix_AllocateChannels(-1); // called with -1 this returns the current number of channels
+    int num_avail = num_chn;
+    for(int i = 0; i < num_chn; i++) {
+        if (Mix_Playing(i) > 0) num_avail--;
+    }
+    return num_avail;
+}

--- a/modules/sound.lobster
+++ b/modules/sound.lobster
@@ -1,4 +1,0 @@
-enum_flags sound_priority:
-    sound_prio_normal
-    sound_prio_elevated
-    sound_prio_high

--- a/modules/sound.lobster
+++ b/modules/sound.lobster
@@ -1,0 +1,4 @@
+enum_flags sound_priority:
+    sound_prio_normal
+    sound_prio_elevated
+    sound_prio_high


### PR DESCRIPTION
This adds a new sound command `sound_channels() -> int` by which the number of currently still available channels is obtained. This is useful in situations when more sounds are potentially generated than channels are available, i.e. when for example many enemy ships shoot lasers, potentially filling up the entire mixer channel range. With this command, a Lobster program can check how many channels are still free and decide to not add another sound of a certain type in order to reserve a channel for a more prioritized sound effect (player ship etc.)