### PR TITLE
Log version

### DIFF
--- a/dev/src/main.cpp
+++ b/dev/src/main.cpp
@@ -166,6 +166,8 @@ int main(int argc, char* argv[]) {
             RegisterCoreLanguageBuiltins(nfr);
         #endif
 
+        LOG_INFO("lobster version " GIT_COMMIT_INFOSTR);
+
         if (fn) fn = StripDirPart(fn);
 
         auto vmargs = VMArgs { nfr, fn ? fn : "" };


### PR DESCRIPTION
Log the version info on start up. With the new jit version it's harder to get to the command line since `to_native` is the default.