### PR TITLE
Replace #defines for Win compilation

### DIFF
--- a/dev/src/lobster/stdafx.h
+++ b/dev/src/lobster/stdafx.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#ifdef _WIN32
+#ifdef _MSC_VER
     #define _CRT_SECURE_NO_WARNINGS
     #define _SCL_SECURE_NO_WARNINGS
     #define _CRTDBG_MAP_ALLOC

--- a/dev/src/lobster/tools.h
+++ b/dev/src/lobster/tools.h
@@ -843,7 +843,7 @@ template<typename T, typename U> const T *AssertIs(const U *o) {
 
 
 inline int PopCount(uint32_t val) {
-    #ifdef _WIN32
+    #ifdef _MSC_VER
         return (int)__popcnt(val);
     #else
         return __builtin_popcount(val);
@@ -851,7 +851,7 @@ inline int PopCount(uint32_t val) {
 }
 
 inline int PopCount(uint64_t val) {
-    #ifdef _WIN32
+    #ifdef _MSC_VER
         #ifdef _WIN64
             return (int)__popcnt64(val);
         #else

--- a/dev/src/physics.cpp
+++ b/dev/src/physics.cpp
@@ -22,7 +22,7 @@
 
 #include "Box2D/Box2D.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #ifndef NDEBUG
 #define new DEBUG_NEW
 #endif

--- a/dev/src/vm.cpp
+++ b/dev/src/vm.cpp
@@ -66,7 +66,7 @@ VMAllocator::VMAllocator(VMArgs &&args) {
 
     vm = new (mem) VM(std::move(args), bcf);
 
-    #ifdef _WIN32
+    #ifdef _MSC_VER
     #ifndef NDEBUG
     #define new DEBUG_NEW
     #endif
@@ -203,7 +203,7 @@ LResource *VM::NewResource(void *v, const ResourceType *t) {
     return r;
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #ifndef NDEBUG
 #define new DEBUG_NEW
 #endif


### PR DESCRIPTION
First step to re-enable MingW/GCC support on Windows