### PR TITLE
Fix crash building error message for function arity mismatch.

### DIFF
--- a/dev/src/lobster/parser.h
+++ b/dev/src/lobster/parser.h
@@ -45,7 +45,7 @@ struct Parser {
     }
 
     template<typename... Ts> void ErrorAt(const Node *what, const Ts &...args) {
-        lex.Error(cat(args...), &what->line);
+        lex.Error(cat(args...), what ? &what->line : nullptr);
     }
 
     template<typename... Ts> void Warn(const Ts &...args) {
@@ -53,7 +53,7 @@ struct Parser {
     }
 
     template<typename... Ts> void WarnAt(const Node *what, const Ts &...args) {
-        lex.Warn(cat(args...), &what->line);
+        lex.Warn(cat(args...), what ? &what->line : nullptr);
     }
 
     void Parse() {


### PR DESCRIPTION
On linux, you can get a segmentation fault when you have a program
that passes the wrong number of parameters to a function.

The crash was occuring because Lex::Error was being passed an
invalid "ln" parameter from the Parser::ErrorAt() function.
ErrorAt() was taking the address of "what->line" when "what"
was null.

Fixes WarnAt() in passing, as it had the same pattern.
