### PR TITLE
Fix for eating bread not reducing hunger.

### DIFF
--- a/tests/goaptest.lobster
+++ b/tests/goaptest.lobster
@@ -21,7 +21,7 @@ run_test("goap"):
         goapaction {
             "eat",
             fn s: (s[bread] > 0 or s[pizza] > 0) and s[hungry] > 0,
-            fn s: if s[bread] > 0: s[bread]-- else: s[pizza]--; s[hungry]--
+            fn s: (if s[bread] > 0: s[bread]-- else: s[pizza]--); s[hungry]--
         }
     ]
 


### PR DESCRIPTION
The goaptest.lobster works fine, but I noticed while trying to change it to force other outcomes that it would not buy flour and make bread when I changed the states and costs. 

Ends up being a syntax problem, where the action of "eat" was accidentally including the "s[hungry]--" in the else block.
