### PR TITLE
Fix asertion when module with private enum is imported.

### DIFF
--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -575,13 +575,15 @@ struct SymbolTable {
     }
 
     void Unregister(const Enum *e, unordered_map<string_view, Enum *> &dict) {
-        for (auto &ev : e->vals) {
-            auto it = enumvals.find(ev->name);
-            assert(it != enumvals.end());
-            enumvals.erase(it);
-        }
         auto it = dict.find(e->name);
-        if (it != dict.end()) dict.erase(it);
+        if (it != dict.end()) {
+            for (auto &ev : e->vals) {
+                auto it = enumvals.find(ev->name);
+                assert(it != enumvals.end());
+                enumvals.erase(it);
+            }
+            dict.erase(it);
+        }
     }
 
     template<typename T> void Unregister(const T *x, unordered_map<string_view, T *> &dict) {


### PR DESCRIPTION
When a private enum was being Unregistered by Parser::CleanupStatements,
the assertion in SymbolTable::Unregister(Enum*, ...) was failing
because the enum's values could not be found.  This is because the
private enum had already been unregistered by the call chain
Parser::ParseStatements() -> SymbolTable::EndOfInclude() ->
ErasePrivate(enums).

The fix is to re-arrange the conditionals so the values aren't
erased if the enum has already been erased.