### PR TITLE
Adds clipping rectangles state

### DIFF
--- a/dev/src/glsystem.cpp
+++ b/dev/src/glsystem.cpp
@@ -73,30 +73,23 @@ void ClearFrameBuffer(const float3 &c) {
     GL_CALL(glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT));
 }
 
-void SetScissorRect(int2 topleft, int2 size, int2& prev_topleft, int2& prev_size) {
+void SetScissorRect(int2 topleft, int2 size, pair<int2, int2>& prev) {
     int2 scrnsz = GetScreenSize();
     GLboolean enabled;
 
     GL_CALL(glGetBooleanv(GL_SCISSOR_TEST, &enabled));
     if (enabled) {
-        GLint curbox[4];
-        GL_CALL(glGetIntegerv(GL_SCISSOR_BOX, curbox)); 
-        prev_topleft.x = curbox[0];
-        prev_topleft.y = curbox[1];
-        prev_size.x = curbox[2];
-        prev_size.y = curbox[3];
+        GL_CALL(glGetIntegerv(GL_SCISSOR_BOX, (GLint*)prev.first.data())); 
     } else {
-        prev_topleft.x = 0;
-        prev_topleft.y = 0;
-        prev_size = scrnsz;
+        prev = {int2_0, scrnsz};
     }
 
-    // Always get bitten by this, glScissor x & y are BOTTOM left, not top left.
-    GL_CALL(glScissor((GLint)topleft.x, (GLint)(scrnsz.y - (topleft.y + size.y)), 
-                     (GLint)size.x, (GLint)size.y));
     if (topleft.x == 0 && topleft.y == 0 && size == scrnsz) {
         GL_CALL(glDisable(GL_SCISSOR_TEST));
     } else {
+        // Always get bitten by this, glScissor x & y are BOTTOM left, not top left.
+        GL_CALL(glScissor((GLint)topleft.x, (GLint)(scrnsz.y - (topleft.y + size.y)), 
+                         (GLint)size.x, (GLint)size.y));
         GL_CALL(glEnable(GL_SCISSOR_TEST));
     }
 }

--- a/dev/src/glsystem.cpp
+++ b/dev/src/glsystem.cpp
@@ -76,10 +76,10 @@ void ClearFrameBuffer(const float3 &c) {
 void SetScissorRect(int2 topleft, int2 size, int2& prev_topleft, int2& prev_size) {
     int2 scrnsz = GetScreenSize();
     GLboolean enabled;
-    GLint curbox[4];
 
     GL_CALL(glGetBooleanv(GL_SCISSOR_TEST, &enabled));
     if (enabled) {
+        GLint curbox[4];
         GL_CALL(glGetIntegerv(GL_SCISSOR_BOX, curbox)); 
         prev_topleft.x = curbox[0];
         prev_topleft.y = curbox[1];

--- a/dev/src/graphics.cpp
+++ b/dev/src/graphics.cpp
@@ -179,23 +179,19 @@ nfr("gl_load_materials", "materialdefs,inline", "SI?", "S?",
         return err[0] ? Value(vm.NewString(err)) : NilVal();
     });
 
-nfr("gl_push_scissor", "x,y,width,height", "IIII", "",
-    "Enables scissor testing so only the pixels in the given rectangle can "
-    "be written.  (x,y) is the top left corner. Scissor state only lasts till "
-    "the end of the frame.",
-    [](StackPtr &, VM &vm, Value &x, Value &y, Value &w, Value &h) {
-   TestGL(vm);
-   PushScissorRect(int4(x.ival(), y.ival(), w.ival(), h.ival()));
-   return NilVal();
-});
+nfr("gl_scissor", "top_left,size", "I}:2I}:2", "I}:2I}:2",
+    "Sets the scissor testing, so only the pixels in the given rectangle can"
+    "be written.  Returns the previous value of the scissor rectangle.",
+    [](StackPtr &sp, VM &vm) {
+        auto size = PopVec<int2>(sp);
+        auto topleft = PopVec<int2>(sp);
+        TestGL(vm);
+        int2 prevtl, prevsize;
 
-nfr("gl_pop_scissor", "", "", "",
-    "pops the last scissor rect from the stack, and restores the previous "
-    "scissor state.",
-    [](StackPtr &, VM &) {
-   PopScissorRect();
-   return NilVal();
-});
+        SetScissorRect(topleft, size, prevtl, prevsize);
+        PushVec(sp, prevtl);
+        PushVec(sp, prevsize);
+    });
 
 nfr("gl_frame", "", "", "B",
     "advances rendering by one frame, swaps buffers, and collects new input events."

--- a/dev/src/graphics.cpp
+++ b/dev/src/graphics.cpp
@@ -179,6 +179,24 @@ nfr("gl_load_materials", "materialdefs,inline", "SI?", "S?",
         return err[0] ? Value(vm.NewString(err)) : NilVal();
     });
 
+nfr("gl_push_scissor", "x,y,width,height", "IIII", "",
+    "Enables scissor testing so only the pixels in the given rectangle can "
+    "be written.  (x,y) is the top left corner. Scissor state only lasts till "
+    "the end of the frame.",
+    [](StackPtr &, VM &vm, Value &x, Value &y, Value &w, Value &h) {
+   TestGL(vm);
+   PushScissorRect(int4(x.ival(), y.ival(), w.ival(), h.ival()));
+   return NilVal();
+});
+
+nfr("gl_pop_scissor", "", "", "",
+    "pops the last scissor rect from the stack, and restores the previous "
+    "scissor state.",
+    [](StackPtr &, VM &) {
+   PopScissorRect();
+   return NilVal();
+});
+
 nfr("gl_frame", "", "", "B",
     "advances rendering by one frame, swaps buffers, and collects new input events."
     " returns false if the closebutton on the window was pressed",

--- a/dev/src/graphics.cpp
+++ b/dev/src/graphics.cpp
@@ -186,11 +186,11 @@ nfr("gl_scissor", "top_left,size", "I}:2I}:2", "I}:2I}:2",
         auto size = PopVec<int2>(sp);
         auto topleft = PopVec<int2>(sp);
         TestGL(vm);
-        int2 prevtl, prevsize;
+        pair<int2, int2> prev;
 
-        SetScissorRect(topleft, size, prevtl, prevsize);
-        PushVec(sp, prevtl);
-        PushVec(sp, prevsize);
+        SetScissorRect(topleft, size, prev);
+        PushVec(sp, prev.first);
+        PushVec(sp, prev.second);
     });
 
 nfr("gl_frame", "", "", "B",

--- a/dev/src/lobster/glinterface.h
+++ b/dev/src/lobster/glinterface.h
@@ -152,7 +152,7 @@ extern void OpenGLCleanup();
 extern void OpenGLFrameStart(const int2 &ssize);
 extern void OpenGLFrameEnd();
 extern void LogGLError(const char *file, int line, const char *call);
-extern void SetScissorRect(int2 topleft, int2 size, int2& prev_topleft, int2& prev_size);
+extern void SetScissorRect(int2 topleft, int2 size, pair<int2,int2>& prev);
 
 extern void Set2DMode(const int2 &ssize, bool lh, bool depthtest = false);
 extern void Set3DMode(float fovy, float ratio, float znear, float zfar);

--- a/dev/src/lobster/glinterface.h
+++ b/dev/src/lobster/glinterface.h
@@ -152,6 +152,8 @@ extern void OpenGLCleanup();
 extern void OpenGLFrameStart(const int2 &ssize);
 extern void OpenGLFrameEnd();
 extern void LogGLError(const char *file, int line, const char *call);
+extern void PushScissorRect(int4 scis);
+extern void PopScissorRect();
 
 extern void Set2DMode(const int2 &ssize, bool lh, bool depthtest = false);
 extern void Set3DMode(float fovy, float ratio, float znear, float zfar);

--- a/dev/src/lobster/glinterface.h
+++ b/dev/src/lobster/glinterface.h
@@ -152,8 +152,7 @@ extern void OpenGLCleanup();
 extern void OpenGLFrameStart(const int2 &ssize);
 extern void OpenGLFrameEnd();
 extern void LogGLError(const char *file, int line, const char *call);
-extern void PushScissorRect(int4 scis);
-extern void PopScissorRect();
+extern void SetScissorRect(int2 topleft, int2 size, int2& prev_topleft, int2& prev_size);
 
 extern void Set2DMode(const int2 &ssize, bool lh, bool depthtest = false);
 extern void Set3DMode(float fovy, float ratio, float znear, float zfar);

--- a/modules/gl.lobster
+++ b/modules/gl.lobster
@@ -51,7 +51,8 @@ def gl_scale(factor, body):
     body()
     gl_pop_model_view()
 
-def gl_scissor(x, y, w, h, body):
-   gl_push_scissor(x, y, w, h)
-   body()
-   gl_pop_scissor()
+def gl_scissor(topleft, size, body):
+    let oldtl, oldsz = gl_scissor(topleft, size)
+    body()
+    gl_scissor(oldtl, oldsz)
+

--- a/modules/gl.lobster
+++ b/modules/gl.lobster
@@ -50,3 +50,8 @@ def gl_scale(factor, body):
     gl_scale(factor)
     body()
     gl_pop_model_view()
+
+def gl_scissor(x, y, w, h, body):
+   gl_push_scissor(x, y, w, h)
+   body()
+   gl_pop_scissor()


### PR DESCRIPTION
Not a bug, but I found a place with some text handling where it would be convenient
to clip to a rectangle, so I added some code for it in a branch.

- Adds gl_scissor_push() and gl_scissor_pop() primatives to push and pop
  clipping rectangles.  The clipping rectangle state is cleared
  at the beginning of each frame, so a missing pop call won't foul
  up subsequent frames.
- Adds a gl_scissor(x, y, w, h, body) function that enables a clipping
  rectangle while body() is active.  (barring return from shennanigans)

Feel free to close this out if it's not something you want or need in the base image.