### PR TITLE
Modify cmake config to static link gcc libraries

### DIFF
--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -238,6 +238,9 @@ elseif(LOBSTER_JIT)
 endif()
 add_executable(${EXE_NAME} ${LOBSTER_SRCS} ${EXTERNAL_SRCS})
 target_link_libraries(${EXE_NAME} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+if(CMAKE_BUILD_TYPE MATCHES RELEASE AND CMAKE_COMPILER_IS_GNUCXX)
+  target_link_libraries(${EXE_NAME} -static-libgcc -static-libstdc++)
+endif()
 if(LOBSTER_ENGINE)
   target_link_libraries(${EXE_NAME}
     ${SDL_LIBRARIES}


### PR DESCRIPTION
When in release mode and using gcc instruct cmake to static link libgcc and libstdc++.

If used in with tdm-gcc it allows the creation of a self-contained lobster executable
that does not require additional shared libraries.