### PR TITLE
Get CMake working on macOS

### DIFF
--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -147,7 +147,10 @@ include_directories(include
                     external/SDLMixer
                     external/freetype/include
                     external/imgui
-                    external/libtcc)
+                    # include only for QUOTE includes: external/libtcc
+                    )
+# include only for QUOTE includes:
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -iquote external/libtcc")
 
 if(LOBSTER_ENGINE)
   find_package(OpenGL REQUIRED)

--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -150,7 +150,11 @@ include_directories(include
                     # include only for QUOTE includes: external/libtcc
                     )
 # include only for QUOTE includes:
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -iquote external/libtcc")
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+  include_directories(external/libtcc) # unless Visual Studio
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -iquote external/libtcc")
+endif()
 
 if(LOBSTER_ENGINE)
   find_package(OpenGL REQUIRED)


### PR DESCRIPTION
Move include for `external/libtcc` to `CMAKE_CXX_FLAGS` to exclude it from SYSTEM includes by using `-iquote`.