### PR TITLE
Restore normalize allowing passthrough of zero vec

### DIFF
--- a/dev/src/builtins.cpp
+++ b/dev/src/builtins.cpp
@@ -710,7 +710,11 @@ nfr("normalize", "vec",  "F}" , "F}",
         VECTORVARS;
         VECTOROPNR(sql += f.fval() * f.fval());
         double m = sqrt(sql);
-        VECTOROPNR(elems[i] = f.fval() / m);
+        if (m == 0.0) {
+            VECTOROPNR((void)f; elems[i] = 0.0);
+        } else {
+            VECTOROPNR(elems[i] = f.fval() / m);
+        }
     });
 
 nfr("dot", "a,b", "F}F}1", "F",

--- a/tests/structtest.lobster
+++ b/tests/structtest.lobster
@@ -38,6 +38,8 @@ run_test("struct"):
         var nv = xy_0
         nv = normalize(xy { 123.0, 456.0 })
         assert abs(magnitude(nv) - 1.0) < 0.001
+        nv = normalize(xy_0)
+        assert abs(magnitude(nv)) < 0.001  // Passthrough of zero vec
         let v = [ xy { 1, 2 }, xy { 3, 4 } ]
         assert v[1] == xy { 3, 4 }
         v[1] = xy { 5, 6 }


### PR DESCRIPTION
Possible fix for #160 (not sure if there's a more efficient way of doing this).