### PR TITLE
Empty dictionary with out of bounds assertion on get() call.

### DIFF
--- a/modules/dictionary.lobster
+++ b/modules/dictionary.lobster
@@ -36,9 +36,10 @@ class dictionary<K,V>:
 
     def get(key:K, default_val:V) -> V:
         let h = hash(key) % size
-        var c = buckets[h]
-        while c:
-            if c.key == key:
-                return c.value
-            c = c.next
+        if h < length(buckets):
+           var c = buckets[h]
+           while c:
+               if c.key == key:
+                   return c.value
+               c = c.next
         return default_val

--- a/tests/misctest.lobster
+++ b/tests/misctest.lobster
@@ -254,6 +254,8 @@ run_test("misc"):
 
     // Dictionary.
     let dict = dictionary<float, float> { 17 }
+    // Check get before first set()
+    assert dict.get(1.0, -1.0) == -1.0
     rnd_seed(0)
     for(32):
         let key = rnd_float()  // 0..1


### PR DESCRIPTION
"buckets" is an empty array until the first set call allocates it.
So a get() before any sets will fail.

Changed set() to check the buckets length, and just return the default
value if the bucket index > length(buckets).