### PR TITLE
Docs: Updated requirements to VS2022

### DIFF
--- a/docs/getting_started.html
+++ b/docs/getting_started.html
@@ -50,7 +50,7 @@ make -j8
 cd ..
 bin/lobster samples/pythtree.lobster</code></pre>
 <h3 id="windows">Windows</h3>
-<p>Pre-Requirements: VS2019 Community edition or better, C++ desktop
+<p>Pre-Requirements: VS2022 Community edition or better, C++ desktop
 tools installed.</p>
 <p>Get https://github.com/aardappel/lobster using your favorite git tool
 (best), or just download a <code>.zip</code> from there otherwise.</p>

--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -28,7 +28,7 @@ terms of building, extending, reusing, and compiling Lobster code to
 C++.</p>
 <p>Lobster has been released under the Apache 2 open source license.</p>
 <h2 id="building-lobster">Building Lobster</h2>
-<p>Lobster uses recent C++17 features, so will need Visual Studio 2019
+<p>Lobster uses recent C++17 features, so will need Visual Studio 2022
 (the free community edition will do), Xcode 10.x, or a recent GCC (9+) /
 Clang (9+) to be compiled.</p>
 <p>Lobster uses OpenGL, SDL 2.x and FreeType, these are included in the

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -43,7 +43,7 @@ bin/lobster samples/pythtree.lobster
 
 ### Windows
 
-Pre-Requirements: VS2019 Community edition or better, C++ desktop tools installed.
+Pre-Requirements: VS2022 Community edition or better, C++ desktop tools installed.
 
 Get https://github.com/aardappel/lobster using your favorite git tool (best),
 or just download a `.zip` from there otherwise.

--- a/docs/source/implementation.md
+++ b/docs/source/implementation.md
@@ -11,7 +11,7 @@ Building Lobster
 ----------------
 
 Lobster uses recent C++17 features, so will need
-Visual Studio 2019 (the free community edition will do), Xcode 10.x, or a recent
+Visual Studio 2022 (the free community edition will do), Xcode 10.x, or a recent
 GCC (9+) / Clang (9+) to be compiled.
 
 Lobster uses OpenGL, SDL 2.x and FreeType, these are included in the repo, so should compile


### PR DESCRIPTION
building with VS2019 failed because build tools v143 are required which
are only available for VS2022