### PR TITLE
Don't reset gl_button frame counter on repeats

### DIFF
--- a/dev/src/sdlsystem.cpp
+++ b/dev/src/sdlsystem.cpp
@@ -62,7 +62,7 @@ struct KeyState {
 
     void Set(bool on) {
         if (on) {
-            frames_down = 1;
+            if (!frames_down) frames_down = 1; // set if not a repeat
             if (frames_up > 1) frames_up = 0;  // Not in this frame, so turn off.
         } else {
             frames_up = 1;


### PR DESCRIPTION
Most game code doesn't care about repeats. But they do care about when a button is pressed versus when it is held, and for how long. Repeats reset the counter, making it seem like a button was pressed when it wasn't. If a program actually wants repeats it can use gl_key_repeat or use the gl_button counter.