### PR TITLE
Disable CMake on non-linux systems

### DIFF
--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 
+if(NOT UNIX) 
+  message(FATAL_ERROR "Cmake configuration is only supported for Linux. For "
+  "other platforms, use the included native projects instead.")
+endif()
+
 project(Lobster)
 
 option(LOBSTER_ENGINE "Build a Lobster with the default engine included" ON)


### PR DESCRIPTION
CMake generation is only supported for Linux/BSD at the moment, so prevent CMake generation on non-supportive platforms.

This would have helped make #205 more obvious.