### PR TITLE
Add `matrix.lobster` for 2x2 float matrices

### DIFF
--- a/modules/matrix.lobster
+++ b/modules/matrix.lobster
@@ -7,16 +7,12 @@ import vec
 struct mat2x2 : xyzw_f
 
     def operator*(o:mat2x2):
-        // This could be expressed with 4 dot product if `this.zw` existed (and 
-        // others)
-        return mat2x2 { x*o.x + y*o.z, x*o.y + y*o.w,
-                        z*o.x + w*o.z, z*o.y + w*o.w }  
+        return mat2x2 { dot(this.xy, o.xz), dot(this.xy, o.yw),
+                        dot(this.zw, o.xz), dot(this.zw, o.yw) }
     
     def operator*(o:xy_f):
-        // This would be nicer if `this.zw` existed.
         return xy_f { dot(o, this.xy),
-                      dot(o, xy_f{z,w})}
-
+                      dot(o, this.zw) }
 
     def operator*(f:float):
         // Note the order is flipped so that it is called with xyzw_f * operator
@@ -39,4 +35,4 @@ struct mat2x2 : xyzw_f
 // The identity matrix:
 // |1 0|
 // |0 1|
-let mat2x2_identity = mat2x2{1.0, 0.0, 0.0, 1.0}
+let mat2x2_identity = mat2x2 { 1.0, 0.0, 0.0, 1.0 }

--- a/modules/matrix.lobster
+++ b/modules/matrix.lobster
@@ -1,0 +1,42 @@
+import vec
+
+// A 2x2 matrix representated as a 4 length vector of x,y,z,w so that
+// |x y|
+// |z w|
+
+struct mat2x2 : xyzw_f
+
+    def operator*(o:mat2x2):
+        // This could be expressed with 4 dot product if `this.zw` existed (and 
+        // others)
+        return mat2x2 { x*o.x + y*o.z, x*o.y + y*o.w,
+                        z*o.x + w*o.z, z*o.y + w*o.w }  
+    
+    def operator*(o:xy_f):
+        // This would be nicer if `this.zw` existed.
+        return xy_f { dot(o, this.xy),
+                      dot(o, xy_f{z,w})}
+
+
+    def operator*(f:float):
+        // Note the order is flipped so that it is called with xyzw_f * operator
+        // instead of mat2x2's
+        return f * this
+
+    def determinant():
+        return x*w - y*z
+
+    def adjugate():
+        return mat2x2{ w, -y, -z, x }
+
+    def inverse():
+        return adjugate() / determinant()
+
+    def trace():
+        return x*w
+
+        
+// The identity matrix:
+// |1 0|
+// |0 1|
+let mat2x2_identity = mat2x2{1.0, 0.0, 0.0, 1.0}

--- a/modules/matrix.lobster
+++ b/modules/matrix.lobster
@@ -14,11 +14,6 @@ struct mat2x2 : xyzw_f
         return xy_f { dot(o, this.xy),
                       dot(o, this.zw) }
 
-    def operator*(f:float):
-        // Note the order is flipped so that it is called with xyzw_f * operator
-        // instead of mat2x2's
-        return f * this
-
     def determinant():
         return x*w - y*z
 

--- a/modules/vec.lobster
+++ b/modules/vec.lobster
@@ -63,6 +63,9 @@ let octant_directions = [
 // FIXME: subtyping should take care of this
 def xy(v):  return xy  { v.x, v.y }
 def xyz(v): return xyz { v.x, v.y, v.z }
+def xz(v):  return xy  { v.x, v.z }
+def yw(v):  return xy  { v.y, v.w }
+def zw(v):  return xy  { v.z, v.w }
 
 // lengthen vectors
 def xyz(v, z):  return xyz  { v.x, v.y, z }

--- a/tests/matrixtest.lobster
+++ b/tests/matrixtest.lobster
@@ -20,7 +20,6 @@ run_test("matrix"):
         assert b - a == mat2x2 { 4.0, 4.0, 4.0, 4.0 }
 
         assert 5.0 * a == mat2x2 { 5.0, 10.0, 15.0, 20.0 }
-        assert a * 5.0 == mat2x2 { 5.0, 10.0, 15.0, 20.0 }
 
         // Matrix specific operations
 

--- a/tests/matrixtest.lobster
+++ b/tests/matrixtest.lobster
@@ -1,0 +1,42 @@
+import testing
+import matrix
+
+run_test("matrix"):
+
+    do():
+        let a = mat2x2 { 1.0, 2.0, 3.0, 4.0 }
+        let b = mat2x2 { 5.0, 6.0, 7.0, 8.0 }
+
+        assert a == a
+        assert a == mat2x2 { 1.0, 2.0, 3.0, 4.0 }
+        assert a != b
+
+        assert 5.0 + a == mat2x2{ 6.0, 7.0, 8.0, 9.0 }
+        assert a + 5.0 == mat2x2{ 6.0, 7.0, 8.0, 9.0 }
+        assert a + b == mat2x2{ 6.0, 8.0, 10.0, 12.0 }
+
+        assert 5.0 - a == mat2x2{ 4.0, 3.0, 2.0, 1.0 }
+        assert a - 5.0 == mat2x2{ -4.0, -3.0, -2.0, -1.0 }
+        assert b - a == mat2x2 { 4.0, 4.0, 4.0, 4.0 }
+
+        assert 5.0 * a == mat2x2{ 5.0, 10.0, 15.0, 20.0 }
+        assert a * 5.0 == mat2x2{ 5.0, 10.0, 15.0, 20.0 }
+
+        // Matrix specific operations
+
+        assert a * b == mat2x2{ 19.0, 22.0, 43.0, 50.0 }
+        assert b * a == mat2x2{ 23.0, 34.0, 31.0, 46.0 }
+
+        assert a.determinant() == -2.0
+        assert a.trace() == 4.0
+        assert a.adjugate() == mat2x2 { 4.0, -2.0, -3.0, 1.0 }
+        assert a.inverse() == mat2x2 { -2.0, 1.0, 1.5, -0.5 }
+
+        assert a * a.inverse() == mat2x2_identity
+
+        // Matrix and Vector Math
+
+        let c = xy_f{ 2.0, 3.0}
+
+        assert a * c == xy_f{ 8.0, 18.0 }
+        assert b * c == xy_f{ 28.0, 38.0 }

--- a/tests/matrixtest.lobster
+++ b/tests/matrixtest.lobster
@@ -11,21 +11,21 @@ run_test("matrix"):
         assert a == mat2x2 { 1.0, 2.0, 3.0, 4.0 }
         assert a != b
 
-        assert 5.0 + a == mat2x2{ 6.0, 7.0, 8.0, 9.0 }
-        assert a + 5.0 == mat2x2{ 6.0, 7.0, 8.0, 9.0 }
-        assert a + b == mat2x2{ 6.0, 8.0, 10.0, 12.0 }
+        assert 5.0 + a == mat2x2 { 6.0, 7.0, 8.0, 9.0 }
+        assert a + 5.0 == mat2x2 { 6.0, 7.0, 8.0, 9.0 }
+        assert a + b == mat2x2 { 6.0, 8.0, 10.0, 12.0 }
 
-        assert 5.0 - a == mat2x2{ 4.0, 3.0, 2.0, 1.0 }
-        assert a - 5.0 == mat2x2{ -4.0, -3.0, -2.0, -1.0 }
+        assert 5.0 - a == mat2x2 { 4.0, 3.0, 2.0, 1.0 }
+        assert a - 5.0 == mat2x2 { -4.0, -3.0, -2.0, -1.0 }
         assert b - a == mat2x2 { 4.0, 4.0, 4.0, 4.0 }
 
-        assert 5.0 * a == mat2x2{ 5.0, 10.0, 15.0, 20.0 }
-        assert a * 5.0 == mat2x2{ 5.0, 10.0, 15.0, 20.0 }
+        assert 5.0 * a == mat2x2 { 5.0, 10.0, 15.0, 20.0 }
+        assert a * 5.0 == mat2x2 { 5.0, 10.0, 15.0, 20.0 }
 
         // Matrix specific operations
 
-        assert a * b == mat2x2{ 19.0, 22.0, 43.0, 50.0 }
-        assert b * a == mat2x2{ 23.0, 34.0, 31.0, 46.0 }
+        assert a * b == mat2x2 { 19.0, 22.0, 43.0, 50.0 }
+        assert b * a == mat2x2 { 23.0, 34.0, 31.0, 46.0 }
 
         assert a.determinant() == -2.0
         assert a.trace() == 4.0
@@ -36,7 +36,7 @@ run_test("matrix"):
 
         // Matrix and Vector Math
 
-        let c = xy_f{ 2.0, 3.0}
+        let c = xy_f { 2.0, 3.0 }
 
-        assert a * c == xy_f{ 8.0, 18.0 }
-        assert b * c == xy_f{ 28.0, 38.0 }
+        assert a * c == xy_f { 8.0, 18.0 }
+        assert b * c == xy_f { 28.0, 38.0 }

--- a/tests/unittest.lobster
+++ b/tests/unittest.lobster
@@ -19,6 +19,7 @@ import gradienttest
 import springstest
 import smallpttest
 import stringtest
+import matrixtest
 
 // Not added to speedtest yet.
 import mischtest

--- a/tests/unittest.lobster
+++ b/tests/unittest.lobster
@@ -19,7 +19,6 @@ import gradienttest
 import springstest
 import smallpttest
 import stringtest
-import matrixtest
 
 // Not added to speedtest yet.
 import mischtest
@@ -27,5 +26,6 @@ import stringtest
 import lifetimetest
 import builtintest
 import operators
+import matrixtest
 
 "the end"  // FIXME: a file can not be only import files?


### PR DESCRIPTION
Makes a new lobster library for handling 2x2 matrices by expressing them in terms of `xyzw_f`. This way a lot of the operators are already well-defined, and only the multiplicative ones need special handling. 