### PR TITLE
Fix TreeSheets build error by renaming _L to _L64 in Lobster

### DIFF
--- a/dev/src/lobster/geom.h
+++ b/dev/src/lobster/geom.h
@@ -491,9 +491,9 @@ const double4 double4_0 = double4(0.0);
 const double3 double3_0 = double3(0.0);
 const double2 double2_0 = double2(0.0);
 
-const iint2 iint2_0 = iint2(0_L);
-const iint2 iint2_1 = iint2(1_L);
-const iint3 iint3_0 = iint3(0_L);
+const iint2 iint2_0 = iint2(0_L64);
+const iint2 iint2_1 = iint2(1_L64);
+const iint3 iint3_0 = iint3(0_L64);
 
 const byte4 byte4_0   = byte4((uint8_t)0);
 const byte4 byte4_255 = byte4((uint8_t)255);

--- a/dev/src/lobster/tools.h
+++ b/dev/src/lobster/tools.h
@@ -31,7 +31,7 @@ typedef ptrdiff_t ssize_t;
 
 // Custom _L suffix, since neither L (different size on win/nix) or LL
 // (does not convert to int64_t on nix!) is portable.
-inline constexpr iint operator"" _L(unsigned long long int c) {
+inline constexpr iint operator"" _L64(unsigned long long int c) {
     return (iint)c;
 }
 

--- a/dev/src/vm.cpp
+++ b/dev/src/vm.cpp
@@ -641,7 +641,7 @@ void VM::StartWorkers(iint numthreads) {
     if (is_worker) Error("workers can\'t start more worker threads");
     if (tuple_space) Error("workers already running");
     // Stop bad values from locking up the machine :)
-    numthreads = std::min(numthreads, 256_L);
+    numthreads = std::min(numthreads, 256_L64);
     tuple_space = new TupleSpace(bcf->udts()->size());
     for (iint i = 0; i < numthreads; i++) {
         // Create a new VM that should own all its own memory and be completely independent


### PR DESCRIPTION
Due to this, TreeSheets was not building on OpenBSD.

ref: https://github.com/aardappel/treesheets/issues/271