### PR TITLE
Do not read garbage memory.

### DIFF
--- a/dev/src/cubegen.cpp
+++ b/dev/src/cubegen.cpp
@@ -173,7 +173,7 @@ uint8_t FindClosestNormal(float3 normal) {
 const size_t palette_size = 256 * sizeof(byte4);
 
 size_t NewPalette(const byte4 *p) {
-    auto hash = FNV1A64(string_view((const char *)&p, palette_size));
+    auto hash = FNV1A64(string_view((const char *)p, palette_size));
     // See if there's an existing matching palette.
     for (auto [pali, pal] : enumerate(palettes)) {
         if (pal.hash == hash &&  // Quick reject.


### PR DESCRIPTION
NewPalette() was reading random memory when using the std::string_view() of unitialized memory.

As can be witnessed with valgrind:
```
==73854== Conditional jump or move depends on uninitialised value(s)
==73854==    at 0x8A0F9C: lobster::NewPalette(geom::vec<unsigned char, 4> const*) (dev/src/cubegen.cpp:179)
==73854==    by 0x8A1344: lobster::NewWorld(geom::vec<int, 3> const&, unsigned long) (dev/src/cubegen.cpp:202)
==73854==    by 0x8A25D0: AddCubeGen(lobster::NativeRegistry&)::$_1::operator()(lobster::Value*&, lobster::VM&) const (dev/src/cubegen.cpp:241)
==73854==    by 0x8A257C: AddCubeGen(lobster::NativeRegistry&)::$_1::__invoke(lobster::Value*&, lobster::VM&) (dev/src/cubegen.cpp:240)
==73854==    by 0x9D064E: lobster::U_BCALLRETV(lobster::VM&, lobster::Value*, int, int) (dev/src/lobster/vmops.h:269)
==73854==    by 0x9D0605: CVM_BCALLRETV (dev/src/vm.cpp:813)
==73854==    by 0x5F05D56: ???
==73854==    by 0x5F08CDE: ???
==73854==    by 0x5F08D31: ???
==73854==    by 0x9CD1B6: lobster::VM::EvalProgram() (dev/src/vm.cpp:524)
==73854==    by 0x7BA611: lobster::RunTCC(lobster::NativeRegistry&, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, char const*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, lobster::TraceMode, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool)::$_20::operator()(void**) const (dev/src/compiler.cpp:382)
==73854==    by 0x7BA451: bool std::__invoke_impl<bool, lobster::RunTCC(lobster::NativeRegistry&, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, char const*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, lobster::TraceMode, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool)::$_20&, void**>(std::__invoke_other, lobster::RunTCC(lobster::NativeRegistry&, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, char const*, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&&, lobster::TraceMode, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, int, bool)::$_20&, void**&&) (invoke.h:61)
==73854==  Uninitialised value was created by a stack allocation
==73854==    at 0x8A0EE0: lobster::NewPalette(geom::vec<unsigned char, 4> const*) (dev/src/cubegen.cpp:175)
```

Fix is to read the memory that the pointer points to, not the memory that holds the pointer.
