### PR TITLE
Avoid comparing against uninitialized expiration value for particles.

### DIFF
--- a/dev/include/Box2D/Particle/b2ParticleSystem.cpp
+++ b/dev/include/Box2D/Particle/b2ParticleSystem.cpp
@@ -704,6 +704,10 @@ int32 b2ParticleSystem::CreateParticle(const b2ParticleDef& def)
 	{
 		m_handleIndexBuffer.data[index] = NULL;
 	}
+	if (m_expirationTimeBuffer.data)
+	{
+		m_expirationTimeBuffer.data[index] = 0;
+	}
 	Proxy& proxy = m_proxyBuffer.Append();
 
 	// If particle lifetimes are enabled or the lifetime is set in the particle


### PR DESCRIPTION
Don't use uninitialised expiration values.

The particle system tries to be lazy when setting expiration values.
When doing so, it will compare the new value to an uninitialised value.
We should set the value to zero, before we ever compare to it.

```
==92419== Conditional jump or move depends on uninitialised value(s)
==92419==    at 0xBFF5C5: b2ParticleSystem::SetParticleLifetime(int, float) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:4255)
==92419==    by 0xBFE831: b2ParticleSystem::CreateParticle(b2ParticleDef const&) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:718)
==92419==    by 0xC0045A: b2ParticleSystem::CreateParticleForGroup(b2ParticleGroupDef const&, b2Transform const&, b2Vec2 const&) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:876)
==92419==    by 0xC007D0: b2ParticleSystem::CreateParticlesFillShapeForGroup(b2Shape const*, b2ParticleGroupDef const&, b2Transform const&) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:937)
==92419==    by 0xC00884: b2ParticleSystem::CreateParticlesWithShapeForGroup(b2Shape const*, b2ParticleGroupDef const&, b2Transform const&) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:954)
==92419==    by 0xC00A25: b2ParticleSystem::CreateParticleGroup(b2ParticleGroupDef const&) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:1062)
==92419==    by 0x98DEFB: AddPhysics(lobster::NativeRegistry&)::$_14::operator()(lobster::Value*&, lobster::VM&) const (dev/src/physics.cpp:302)
==92419==    by 0x98DD6C: AddPhysics(lobster::NativeRegistry&)::$_14::__invoke(lobster::Value*&, lobster::VM&) (dev/src/physics.cpp:292)
==92419==    by 0x9D064E: lobster::U_BCALLRETV(lobster::VM&, lobster::Value*, int, int) (dev/src/lobster/vmops.h:269)
==92419==    by 0x9D0605: CVM_BCALLRETV (dev/src/vm.cpp:813)
==92419==    by 0x5F14DD7: ???
==92419==    by 0x5F15D9C: ???
==92419==  Uninitialised value was created by a heap allocation
==92419==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==92419==    by 0xBDB167: b2AllocDefault(int, void*) (dev/include/Box2D/Common/b2Settings.cpp:58)
==92419==    by 0xBDB1C0: b2Alloc(int) (dev/include/Box2D/Common/b2Settings.cpp:96)
==92419==    by 0xBDB8D8: b2TrackedBlock::Allocate(unsigned int) (dev/include/Box2D/Common/b2TrackedBlock.cpp:55)
==92419==    by 0xBDB9CE: b2TrackedBlockAllocator::Allocate(unsigned int) (dev/include/Box2D/Common/b2TrackedBlock.cpp:93)
==92419==    by 0xBDA0FD: b2BlockAllocator::Allocate(int) (dev/include/Box2D/Common/b2BlockAllocator.cpp:114)
==92419==    by 0xC12503: int* b2ParticleSystem::ReallocateBuffer<int>(int*, int, int) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:489)
==92419==    by 0xC124BB: int* b2ParticleSystem::ReallocateBuffer<int>(int*, int, int, int, bool) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:515)
==92419==    by 0xC0EF44: int* b2ParticleSystem::ReallocateBuffer<int>(b2ParticleSystem::UserOverridableBuffer<int>*, int, int, bool) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:526)
==92419==    by 0xBFE415: b2ParticleSystem::ReallocateInternalAllocatedBuffers(int) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:631)
==92419==    by 0xBFE52B: b2ParticleSystem::CreateParticle(b2ParticleDef const&) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:654)
==92419==    by 0xC0045A: b2ParticleSystem::CreateParticleForGroup(b2ParticleGroupDef const&, b2Transform const&, b2Vec2 const&) (dev/include/Box2D/Particle/b2ParticleSystem.cpp:876)
```