### PR TITLE
Texture initialization rework

### DIFF
--- a/dev/src/gltexture.cpp
+++ b/dev/src/gltexture.cpp
@@ -109,6 +109,7 @@ Texture CreateTexture(string_view name, const uint8_t *buf, int3 dim, int tf) {
     } else if(tf & TF_3D) {
 		#ifndef __EMSCRIPTEN__
 			int mipl = 0;
+            // TODO: Ideally use glTexStorage3D if no initialization buffer provided
 			for (auto d = dim; tf & TF_BUFFER_HAS_MIPS ? d.volume() : !mipl; d /= 2) {
 				GL_CALL(glTexImage3D(textype, mipl, internalformat, d.x, d.y, d.z, 0,
 									 bufferformat, buffercomponent, buf));
@@ -120,6 +121,7 @@ Texture CreateTexture(string_view name, const uint8_t *buf, int3 dim, int tf) {
 		#endif
     } else {
         int mipl = 0;
+        // TODO: Ideally use glTexStorage2D if no initialization buffer provided
         for (auto d = dim.xy(); tf & TF_BUFFER_HAS_MIPS ? d.volume() : !mipl; d /= 2) {
             for (int i = 0; i < texnumfaces; i++) {
                 GL_CALL(glTexImage2D(teximagetype + i, mipl, internalformat, d.x, d.y, 0,
@@ -196,7 +198,11 @@ void FreeImageFromFile(uint8_t *img) {
     stbi_image_free(img);
 }
 
-Texture CreateBlankTexture(string_view name, const int3 &size, const float4 &color, int tf) {
+Texture CreateBlankTexture(string_view name, const int3 &size, int tf) {
+    return CreateTexture(name, nullptr, size, tf);
+}
+
+Texture CreateColoredTexture(string_view name, const int3 &size, const float4 &color, int tf) {
     if (tf & TF_MULTISAMPLE) {
         return CreateTexture(name, nullptr, size, tf);  // No buffer required.
     } else {

--- a/dev/src/glvr.cpp
+++ b/dev/src/glvr.cpp
@@ -179,8 +179,8 @@ void VREye(int eye, float znear, float zfar) {
     if (!vrsys) return;
     auto retf = TF_CLAMP | TF_NOMIPMAP;
     auto mstf = retf | TF_MULTISAMPLE;
-    if (!mstex[eye].id) mstex[eye] = CreateBlankTexture("vr_mstex", rtsize, float4_0, mstf);
-    if (!retex[eye].id) retex[eye] = CreateBlankTexture("vr_retex", rtsize, float4_0, retf);
+    if (!mstex[eye].id) mstex[eye] = CreateColoredTexture("vr_mstex", rtsize, float4_0, mstf);
+    if (!retex[eye].id) retex[eye] = CreateColoredTexture("vr_retex", rtsize, float4_0, retf);
     SwitchToFrameBuffer(mstex[eye], GetScreenSize(), true, mstf, retex[eye]);
     auto proj =
         FromOpenVR(vrsys->GetProjectionMatrix((vr::EVREye)eye, znear, zfar));

--- a/dev/src/graphics.cpp
+++ b/dev/src/graphics.cpp
@@ -1068,15 +1068,26 @@ nfr("gl_create_texture", "matrix,textureformat", "F}:4]]I?", "R:texture",
         return Value(vm.NewResource(&texture_type, new OwnedTexture(tex)));
     });
 
-nfr("gl_create_blank_texture", "size,color,textureformat", "I}:3F}:4I?", "R:texture",
+nfr("gl_create_blank_texture", "size,textureformat", "I}:3I?", "R:texture",
     "creates a blank texture (for use as frame buffer or with compute shaders)."
+    " see texture.lobster for texture format",
+    [](StackPtr &sp, VM &vm) {
+        TestGL(vm);
+        auto tf = Pop(sp).intval();
+        auto size = PopVec<int3>(sp);
+        auto tex = CreateBlankTexture("gl_create_blank_texture", size, tf);
+        Push(sp, vm.NewResource(&texture_type, new OwnedTexture(tex)));
+    });
+
+nfr("gl_create_colored_texture", "size,color,textureformat", "I}:3F}:4I?", "R:texture",
+    "creates a colored texture (for use as frame buffer or with compute shaders)."
     " see texture.lobster for texture format",
     [](StackPtr &sp, VM &vm) {
         TestGL(vm);
         auto tf = Pop(sp).intval();
         auto col = PopVec<float4>(sp);
         auto size = PopVec<int3>(sp);
-        auto tex = CreateBlankTexture("gl_create_blank_texture", size, col, tf);
+        auto tex = CreateColoredTexture("gl_create_colored_texture", size, col, tf);
         Push(sp, vm.NewResource(&texture_type, new OwnedTexture(tex)));
     });
 

--- a/dev/src/lobster/glinterface.h
+++ b/dev/src/lobster/glinterface.h
@@ -261,7 +261,8 @@ enum TextureFlag {
 
 extern Texture CreateTexture(string_view name, const uint8_t *buf, int3 dim, int tf = TF_NONE);
 extern Texture CreateTextureFromFile(string_view name, int tf = TF_NONE);
-extern Texture CreateBlankTexture(string_view name, const int3 &size, const float4 &color,
+extern Texture CreateBlankTexture(string_view name, const int3 &size, int tf = TF_NONE);
+extern Texture CreateColoredTexture(string_view name, const int3 &size, const float4 &color,
                                   int tf = TF_NONE);
 extern void DeleteTexture(Texture &id);
 extern bool SetTexture(int textureunit, const Texture &tex, int tf = TF_NONE);

--- a/modules/texture.lobster
+++ b/modules/texture.lobster
@@ -53,7 +53,7 @@ def loadtexturecached(name, tf:texture_format = texture_format_none):
 // Depth texture automatically created if depth is true and depthtex is nil.
 def render_to_texture(tex, size, depth, depthtex, texture_format, f):
     if not tex or gl_texture_size(tex) != size:
-        tex = gl_create_blank_texture(xyz(size, 0), color_clear, texture_format)
+        tex = gl_create_colored_texture(xyz(size, 0), color_clear, texture_format)
     assert tex  // FIXME
     assert gl_switch_to_framebuffer(tex, depth, texture_format, nil, depthtex)
     f()
@@ -62,7 +62,7 @@ def render_to_texture(tex, size, depth, depthtex, texture_format, f):
 
 def create_depth_texture(tex, size):
     if not tex or gl_texture_size(tex) != size:
-        tex = gl_create_blank_texture(xyz(size, 0), color_black, texture_format_depth |
+        tex = gl_create_colored_texture(xyz(size, 0), color_black, texture_format_depth |
             texture_format_nomipmap | texture_format_clamp | texture_format_nearest_mag)
     assert tex  // FIXME
     return tex


### PR DESCRIPTION
`gl_create_blank_texture` now creates a texture without initializing the data, while `gl_create_colored_texture` is used for initializing a texture with a given color