### PR TITLE
Allow toggling comments in Sublime Text

### DIFF
--- a/docs/sublime/lobster.tmPreferences
+++ b/docs/sublime/lobster.tmPreferences
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+   <key>name</key>
+   <string>Miscellaneous</string>
+   <key>scope</key>
+   <string>source.lobster</string>
+   <key>settings</key>
+   <dict>
+      <key>shellVariables</key>
+      <array>
+         <dict>
+            <key>name</key>
+            <string>TM_COMMENT_START</string>
+            <key>value</key>
+            <string>// </string>
+         </dict>
+         <dict>
+            <key>name</key>
+            <string>TM_COMMENT_START_2</string>
+            <key>value</key>
+            <string>/* </string>
+         </dict>
+         <dict>
+            <key>name</key>
+            <string>TM_COMMENT_END_2</string>
+            <key>value</key>
+            <string> */</string>
+         </dict>
+      </array>
+   </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Allows Ctrl+/ to toggle line comments.
Allows Ctrl+Shift+/ to toggle block comments.