### PR TITLE
add more window init flags

### DIFF
--- a/dev/src/lobster/sdlinterface.h
+++ b/dev/src/lobster/sdlinterface.h
@@ -15,7 +15,15 @@
 // simple interface for SDL (that doesn't depend on its headers)
 
 // See also modules/gl.lobster
-enum InitFlags { INIT_FULLSCREEN = 1, INIT_NO_VSYNC = 2, INIT_LINEAR_COLOR = 4, INIT_NATIVE = 8, INIT_MAXIMIZED = 16 };
+enum InitFlags {
+    INIT_FULLSCREEN = 1,
+    INIT_NO_VSYNC = 2,
+    INIT_LINEAR_COLOR = 4,
+    INIT_NATIVE = 8,
+    INIT_MAXIMIZED = 16,
+    INIT_NO_RESIZABLE = 32,
+    INIT_BORDERLESS = 64,
+};
 
 extern string SDLInit(string_view_nt title, const int2 &screensize, InitFlags flags, int samples);
 extern void SDLRequireGLVersion(int major, int minor);

--- a/dev/src/sdlsystem.cpp
+++ b/dev/src/sdlsystem.cpp
@@ -401,7 +401,9 @@ string SDLInit(string_view_nt title, const int2 &desired_screensize, InitFlags f
             title.c_str(),
             SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
             screensize.x, screensize.y,
-            SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI |
+            SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_ALLOW_HIGHDPI |
+                (flags & INIT_NO_RESIZABLE ? 0 : SDL_WINDOW_RESIZABLE) |
+                (flags & INIT_BORDERLESS ? SDL_WINDOW_BORDERLESS : 0) |
                 (flags & INIT_MAXIMIZED ? SDL_WINDOW_MAXIMIZED : 0) |
                 (flags & INIT_FULLSCREEN ? (flags & INIT_NATIVE ? SDL_WINDOW_FULLSCREEN
                                                                 : SDL_WINDOW_FULLSCREEN_DESKTOP)

--- a/modules/gl.lobster
+++ b/modules/gl.lobster
@@ -8,6 +8,8 @@ enum_flags window_init:
     window_init_linear_color     // If not set, SRGB.
     window_init_native           // If not set, borderless (if fullscreen).
     window_init_maximized        // If not set, normal window (if windowed).
+    window_init_no_resizable     // If not set, window is resizable (if windowed).
+    window_init_borderless       // If not set, window is bordered (if windowed).
 
 // These are versions of built-in transform and state functions that restore
 // the state after executing body.


### PR DESCRIPTION
Add flags for controlling resizability and border, which should be useful when developing small/retro games.