### PR TITLE
Remove SDLSoundInit Emscripten directive

### DIFF
--- a/dev/src/sdlaudiosfxr.cpp
+++ b/dev/src/sdlaudiosfxr.cpp
@@ -417,11 +417,6 @@ Mix_Chunk *LoadSound(string_view filename, SoundType st) {
 bool SDLSoundInit() {
     if (sound_init) return true;
 
-    #ifdef __EMSCRIPTEN__
-    // Distorted in firefox and no audio at all in chrome, disable for now.
-        return false;
-    #endif
-
     for (int i = 0; i < SDL_GetNumAudioDrivers(); ++i) {
         LOG_INFO("Audio driver available ", SDL_GetAudioDriver(i));
     }


### PR DESCRIPTION
From what I can tell, this Emscripten directive was introduced at commit 196c5cd7243927d45f89340df8e667096592f96a. Tested on Chrome and Firefox, I'm not experiencing the noise distortion that the comment is referencing anymore; I think it's safe to remove this restriction.