### PR TITLE
Added Macos Matrix for Arm support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,10 +83,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
-            artifact_name: Mac Lobster binary
+          - os: macos-12
+            artifact_name: Mac (Apple x64 Intel) Lobster binary
           - os: macos-14
-            artifact_name: Mac (Apple Silicon) Lobster binary
+            artifact_name: Mac (Apple ARM Silicon) Lobster binary
     steps:
     - uses: actions/checkout@v1
     - name: cmake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,45 +78,39 @@ jobs:
         path: bin/lobster.exe
 
   build-mac:
-    name: Build Mac
-    runs-on: macos-latest
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            artifact_name: Mac Lobster binary
+          - os: macos-14
+            artifact_name: Mac (Apple Silicon) Lobster binary
     steps:
     - uses: actions/checkout@v1
-    - name: cmake
-      working-directory: dev
-      run: sh build_osx.sh
-    - name: build
-      working-directory: dev/xcode-cmake
-      run: xcodebuild -toolchain clang -configuration Release -target lobster
-    - name: test
-      run: bin/lobster tests/unittest.lobster
-    - name: test lsp
-      run: cd dev/lsp && npm install && npm test
-    - name: upload build artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: Mac Lobster binary
-        path: bin/lobster
 
-  build-mac-silicon:
-    name: Build Mac (Apple Silicon)
-    runs-on: macos-14
-    steps:
-    - uses: actions/checkout@v1
     - name: cmake
       working-directory: dev
       run: sh build_osx.sh
+
     - name: build
       working-directory: dev/xcode-cmake
       run: xcodebuild -toolchain clang -configuration Release -target lobster
+
     - name: test
       run: bin/lobster tests/unittest.lobster
+
     - name: test lsp
-      run: cd dev/lsp && npm install && npm test
+      run: |
+        cd dev/lsp
+        npm install
+        npm test
+
     - name: upload build artifacts
       uses: actions/upload-artifact@v1
       with:
-        name: Mac (Apple Silicon) Lobster binary
+        name: ${{ matrix.artifact_name }}
         path: bin/lobster
         
   build-android:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,27 @@ jobs:
         name: Mac Lobster binary
         path: bin/lobster
 
+  build-mac-silicon:
+    name: Build Mac Silicon
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v1
+    - name: cmake
+      working-directory: dev
+      run: sh build_osx.sh
+    - name: build
+      working-directory: dev/xcode-cmake
+      run: xcodebuild -toolchain clang -configuration Release -target lobster
+    - name: test
+      run: bin/lobster tests/unittest.lobster
+    - name: test lsp
+      run: cd dev/lsp && npm install && npm test
+    - name: upload build artifacts
+      uses: actions/upload-artifact@v1
+      with:
+        name: Mac Lobster binary
+        path: bin/lobster
+        
   build-android:
     name: Build Android (on Linux)
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,24 +89,19 @@ jobs:
             artifact_name: Mac (Apple Silicon) Lobster binary
     steps:
     - uses: actions/checkout@v1
-
     - name: cmake
       working-directory: dev
       run: sh build_osx.sh
-
     - name: build
       working-directory: dev/xcode-cmake
       run: xcodebuild -toolchain clang -configuration Release -target lobster
-
     - name: test
       run: bin/lobster tests/unittest.lobster
-
     - name: test lsp
       run: |
         cd dev/lsp
         npm install
         npm test
-
     - name: upload build artifacts
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
         path: bin/lobster
 
   build-mac-silicon:
-    name: Build Mac Silicon
+    name: Build Mac (Apple Silicon)
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v1
@@ -116,7 +116,7 @@ jobs:
     - name: upload build artifacts
       uses: actions/upload-artifact@v1
       with:
-        name: Mac Lobster binary
+        name: Mac (Apple Silicon) Lobster binary
         path: bin/lobster
         
   build-android:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         path: bin/lobster.exe
 
   build-mac:
-    name: Build on ${{ matrix.os }}
+    name: Build Mac
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         files: |
           lobster_linux_release.zip
   build-mac:
+    name: Release Mac
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         files: |
           lobster_osx_release.zip
   build-mac-silicon:
-    name: Build Mac Silicon
+    name: Build Mac (Apple Silicon)
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,27 @@ jobs:
         name: Release ${{ github.ref_name }}
         files: |
           lobster_osx_release.zip
+  build-mac-silicon:
+    name: Build Mac Silicon
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v1
+    - name: cmake
+      working-directory: dev
+      run: sh build_osx.sh
+    - name: build
+      working-directory: dev/xcode-cmake
+      run: xcodebuild -toolchain clang -configuration Release -target lobster
+    - name: test
+      run: bin/lobster tests/unittest.lobster
+    - name: Zip
+      run: |
+          rm -f bin/*.exe bin/*.dll
+          zip -r lobster_osx_arm_release.zip bin data docs modules samples tests README.md
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        name: Release ${{ github.ref_name }}
+        files: |
+          lobster_osx_arm_release.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,50 +63,33 @@ jobs:
         files: |
           lobster_linux_release.zip
   build-mac:
-    name: Build Mac
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            artifact_name: lobster_osx_release.zip
+            asset_name: Release ${{ github.ref_name }} for macOS (Intel)
+          - os: macos-14
+            artifact_name: lobster_osx_arm_release.zip
+            asset_name: Release ${{ github.ref_name }} for macOS (Apple Silicon)
     steps:
-    - uses: actions/checkout@v1
-    - name: cmake
-      working-directory: dev
-      run: sh build_osx.sh
-    - name: build
-      working-directory: dev/xcode-cmake
-      run: xcodebuild -toolchain clang -configuration Release -target lobster
-    - name: test
-      run: bin/lobster tests/unittest.lobster
-    - name: Zip
-      run: |
-          rm -f bin/*.exe bin/*.dll
-          zip -r lobster_osx_release.zip bin data docs modules samples tests README.md
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        name: Release ${{ github.ref_name }}
-        files: |
-          lobster_osx_release.zip
-  build-mac-silicon:
-    name: Build Mac (Apple Silicon)
-    runs-on: macos-14
-    steps:
-    - uses: actions/checkout@v1
-    - name: cmake
-      working-directory: dev
-      run: sh build_osx.sh
-    - name: build
-      working-directory: dev/xcode-cmake
-      run: xcodebuild -toolchain clang -configuration Release -target lobster
-    - name: test
-      run: bin/lobster tests/unittest.lobster
-    - name: Zip
-      run: |
-          rm -f bin/*.exe bin/*.dll
-          zip -r lobster_osx_arm_release.zip bin data docs modules samples tests README.md
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        name: Release ${{ github.ref_name }}
-        files: |
-          lobster_osx_arm_release.zip
+      - uses: actions/checkout@v1
+      - name: cmake
+        working-directory: dev
+        run: sh build_osx.sh
+      - name: build
+        working-directory: dev/xcode-cmake
+        run: xcodebuild -toolchain clang -configuration Release -target lobster
+      - name: test
+        run: bin/lobster tests/unittest.lobster
+      - name: Zip
+        run: |
+            rm -f bin/*.exe bin/*.dll
+            zip -r ${{ matrix.artifact_name }} bin data docs modules samples tests README.md
+      - name: Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ matrix.asset_name }}
+          files: ${{ matrix.artifact_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-latest
-            artifact_name: lobster_osx_release.zip
-            asset_name: Release ${{ github.ref_name }} for macOS (Intel)
+          - os: macos-12
+            artifact_name: lobster_osx_x64_release.zip
+            asset_name: Release ${{ github.ref_name }} for macOS (X64 Intel)
           - os: macos-14
             artifact_name: lobster_osx_arm_release.zip
-            asset_name: Release ${{ github.ref_name }} for macOS (Apple Silicon)
+            asset_name: Release ${{ github.ref_name }} for macOS (Apple ARM Silicon)
     steps:
       - uses: actions/checkout@v1
       - name: cmake


### PR DESCRIPTION
Hi,

After opening the Issue #305 as a test I modified the build pipeline and actually the artefact produced works on the M2 Arm64 however it requires a build matrix to support production of a Arm64 binary.