### PR TITLE
fix typo in TextMate grammar

### DIFF
--- a/dev/vscode-ext/syntaxes/lobster.tmLanguage.json
+++ b/dev/vscode-ext/syntaxes/lobster.tmLanguage.json
@@ -90,7 +90,7 @@
           "end": "=",
           "endCaptures": {
             "0": {
-              "name": "punctuation.defintition.lobster"
+              "name": "punctuation.definition.lobster"
             }
           },
           "patterns": [


### PR DESCRIPTION
I didn't test the change, but I remember that highlighting of `let` statements  behave in a strange way.