### PR TITLE
Print builtin function returns and parse it in lsp

### DIFF
--- a/dev/lsp/src/lobster.ts
+++ b/dev/lsp/src/lobster.ts
@@ -154,14 +154,14 @@ export async function queryDefinition(
 			};
 
 			if (match[3]) {
-				const def = match[3].trim();
-				const defmatch = def.match(/^(.+)\((.*)\)$/);
+				const [def, ret] = match[3].split("->");
+				const defmatch = def.match(/^(.+)\((.*)\)$/)
 				if (defmatch) {
 					const parameters = readParameters(defmatch[2]);
 					signature = {
 						name: defmatch[1],
 						parameters,
-						returns: undefined
+						returns: ret ? ret.replace(" ", "").replace(/[()]/g, "").split(",") : undefined
 					};
 				} else {
 					signature = {
@@ -176,15 +176,14 @@ export async function queryDefinition(
 		if (querySignatureB != -1) {
 			const querySignatureE = input.substring(querySignatureB).indexOf('\n');
 			const sub = input.substring(querySignatureB, querySignatureE);
-			const match = sub.match(/^query_signature: (.+)\((.*)\)/);
+			const match = sub.match(/^query_signature: ([^)]+)\(([^)]*)\)(?:->\(([^)]+)\))?/);
 
 			if (!match) throw new Error("Invalid output from lobster: " + sub);
-
 
 			signature = {
 				name: match[1].trim(),
 				parameters: readParameters(match[2].trim()),
-				returns: undefined
+				returns: match[3] ? match[3].replace(" ", "").replace(/[()]/g, "").split(",") : undefined
 			};
 		}
 

--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -48,7 +48,7 @@ SlabAlloc *g_current_slaballoc;
             return g_current_slaballoc->dealloc_small(ptr); \
         }
 #else
-    #define USE_CURRENT_SLABALLOCATOR 
+    #define USE_CURRENT_SLABALLOCATOR
 #endif
 
 struct Ident : Named {
@@ -631,7 +631,7 @@ struct SymbolTable {
         for (auto tv  : typevars)         delete tv;
         for (auto su  : specudts)         delete su;
     }
-    
+
     bool MaybeNameSpace(string_view name) {
         return !current_namespace.empty() && name.find(".") == name.npos;
     }
@@ -1380,6 +1380,14 @@ inline string Signature(const NativeFun &nf) {
         FormatArg(r, arg.name, i, arg.type);
     }
     r += ")";
+    if (nf.retvals.size() > 0){
+        r += "->(";
+        for (auto [i, retval] : enumerate(nf.retvals)) {
+            if (i) r += ", ";
+            r += TypeName(retval.type);
+        }
+        r += ")";
+    }
     return r;
 }
 


### PR DESCRIPTION
Print builtin function returns in format
`funcname(param: type) -> (typeA, typeB)`

also fixes lsp crash on lookup for user function (was failed to parse returns)

![image](https://github.com/user-attachments/assets/ae0220f1-bca4-41c5-a3e5-69b9059118f1)
(above highlight is somewhat broken, but I didn't touch it)
![image](https://github.com/user-attachments/assets/8de52dff-06e4-4834-a257-843ab079a411)
