### PR TITLE
 Print builtin function returns and parse it in lsp

### DIFF
--- a/dev/lsp/src/lobster.ts
+++ b/dev/lsp/src/lobster.ts
@@ -154,14 +154,14 @@ export async function queryDefinition(
 			};
 
 			if (match[3]) {
-				const def = match[3].trim();
-				const defmatch = def.match(/^(.+)\((.*)\)$/);
+				const [def, ret] = match[3].split("->");
+				const defmatch = def.match(/^(.+)\((.*)\)$/)
 				if (defmatch) {
 					const parameters = readParameters(defmatch[2]);
 					signature = {
 						name: defmatch[1],
 						parameters,
-						returns: undefined
+						returns: ret ? ret.replace(" ", "").replace(/[()]/g, "").split(",") : undefined
 					};
 				} else {
 					signature = {
@@ -176,15 +176,14 @@ export async function queryDefinition(
 		if (querySignatureB != -1) {
 			const querySignatureE = input.substring(querySignatureB).indexOf('\n');
 			const sub = input.substring(querySignatureB, querySignatureE);
-			const match = sub.match(/^query_signature: (.+)\((.*)\)/);
+			const match = sub.match(/^query_signature: ([^)]+)\(([^)]*)\)(?:->\(([^)]+)\))?/);
 
 			if (!match) throw new Error("Invalid output from lobster: " + sub);
-
 
 			signature = {
 				name: match[1].trim(),
 				parameters: readParameters(match[2].trim()),
-				returns: undefined
+				returns: match[3] ? match[3].replace(" ", "").replace(/[()]/g, "").split(",") : undefined
 			};
 		}
 

--- a/dev/lsp/src/lobster.ts
+++ b/dev/lsp/src/lobster.ts
@@ -3,215 +3,229 @@ import { Diagnostic, DiagnosticSeverity, integer, uinteger } from 'vscode-langua
 import { LobsterSettings } from './lsp';
 
 export interface LobsterLocation {
-	file: string,
-	line: integer
+    file: string,
+    line: integer
 }
 
 export interface LobsterSignatureParameter {
-	name: string,
-	type: string
+    name: string,
+    type: string
 }
 
 export interface LobsterVariableSignature {
-	name: string,
-	type: string
+    name: string,
+    type: string
 }
 
 export interface LobsterFunctionSignature {
-	name: string,
-	parameters: LobsterSignatureParameter[]
-	returns?: string[]
+    name: string,
+    parameters: LobsterSignatureParameter[]
+    returns?: string[]
 }
 
 export interface LobsterBuiltinsDoc {
-  args: LobsterSignatureParameter[];
-  doc: string;
-  funcname: string;
-  returns?: string[];
-  subsystem: string;
+    args: LobsterSignatureParameter[];
+    doc: string;
+    funcname: string;
+    returns?: string[];
+    subsystem: string;
 }
 
 export type LobsterSignature = LobsterVariableSignature | LobsterFunctionSignature;
 
 export interface QueryDefinitionResult {
-	declartionLocation?: LobsterLocation,
-	signature?: LobsterSignature
+    declartionLocation?: LobsterLocation,
+    signature?: LobsterSignature
 }
 
 function callLobster(
-	settings: LobsterSettings,
-	output: (output: string) => void,
-	...params: string[]
+    settings: LobsterSettings,
+    output: (output: string) => void,
+    ...params: string[]
 ) {
-	const command =
-		settings.executable + " " +
-		settings.imports.map(i => "--import " + i).join(" ") + " " +
-		params.join(" ");
+    const command =
+        settings.executable + " " +
+        settings.imports.map(i => "--import " + i).join(" ") + " " +
+        params.join(" ");
 
 
-	console.debug(command);
-	exec(command, (error, stdout, stderr) => {
-		if (stderr) {
-			console.error(`Lobster (${settings.executable}) returned with output: ${stderr}`);
-			return;
-		}
+    console.debug(command);
+    exec(command, (error, stdout, stderr) => {
+        if (stderr) {
+            console.error(`Lobster (${settings.executable}) returned with output: ${stderr}`);
+            return;
+        }
 
-		output(stdout);
-	});
+        output(stdout);
+    });
 }
 
 export async function parseLobster(
-	settings: LobsterSettings,
-	file: string,
-	...args: string[]
+    settings: LobsterSettings,
+    file: string,
+    ...args: string[]
 ): Promise<Diagnostic[]> {
-	function parseOutput(input: string): Diagnostic[] {
-		if (input.length == 0) return [];
+    function parseOutput(input: string): Diagnostic[] {
+        if (input.length == 0) return [];
 
-		if (input.startsWith("can't open file")) {
-			return []; // TODO make "can't open file" a normal error instead of an unformatted error
-		}
+        if (input.startsWith("can't open file")) {
+            return []; // TODO make "can't open file" a normal error instead of an unformatted error
+        }
 
-		const regex = /^(.*)\((\d+)\): (warning|error): (.*)/g;
-		let match;
-		const output: Diagnostic[] = [];
+        const regex = /^(.*)\((\d+)\): (warning|error): (.*)/g;
+        let match;
+        const output: Diagnostic[] = [];
 
-		while ((match = regex.exec(input))) {
-			const at = match[1];
-			if (!file.endsWith(at)) return [];
+        while ((match = regex.exec(input))) {
+            const at = match[1];
+            if (!file.endsWith(at)) return [];
 
-			const line = parseInt(match[2]) - 1; // Its zero based
-			const messageType = match[3].trim();
-			const message = match[4].trim();
+            const line = parseInt(match[2]) - 1; // Its zero based
+            const messageType = match[3].trim();
+            const message = match[4].trim();
 
-			const severity = messageType == "warning" ?
-				DiagnosticSeverity.Warning :
-				DiagnosticSeverity.Error;
+            const severity = messageType == "warning" ?
+                DiagnosticSeverity.Warning :
+                DiagnosticSeverity.Error;
 
-			output.push({
-				range: {
-					start: { line, character: 0 },
-					end: { line, character: uinteger.MAX_VALUE }
-				},
-				message,
-				severity
-			});
-		}
+            output.push({
+                range: {
+                    start: { line, character: 0 },
+                    end: { line, character: uinteger.MAX_VALUE }
+                },
+                message,
+                severity
+            });
+        }
 
-		if (output.length == 0) throw new Error("Invalid output from lobster: " + input);
+        if (output.length == 0) throw new Error("Invalid output from lobster: " + input);
 
-		return output;
-	}
+        return output;
+    }
 
 
-	return new Promise<Diagnostic[]>(back => callLobster(
-		settings,
-		i => back(parseOutput(i)),
-		...(settings.experimental ? [ "--errors", "99" ] : []),
-		"--compile-only",
-		file,
-		...args
-	));
+    return new Promise<Diagnostic[]>(back => callLobster(
+        settings,
+        i => back(parseOutput(i)),
+        ...(settings.experimental ? ["--errors", "99"] : []),
+        "--compile-only",
+        file,
+        ...args
+    ));
 }
 
 export async function getBuiltinsDoc(
-  settings: LobsterSettings,
+    settings: LobsterSettings,
 ): Promise<LobsterBuiltinsDoc[]> {
-  function parseOutput(input: string): LobsterBuiltinsDoc[] {
-    const parsedData: LobsterBuiltinsDoc[] = JSON.parse(input);
-    return parsedData;
-  }
+    function parseOutput(input: string): LobsterBuiltinsDoc[] {
+        const parsedData: LobsterBuiltinsDoc[] = JSON.parse(input);
+        return parsedData;
+    }
 
-  return new Promise<LobsterBuiltinsDoc[]>((back) =>
-    callLobster(settings, (i) => back(parseOutput(i)), "--gen-builtins-json"),
-  );
+    return new Promise<LobsterBuiltinsDoc[]>((back) =>
+        callLobster(settings, (i) => back(parseOutput(i)), "--gen-builtins-json"),
+    );
+}
+
+function parseDefinition(
+    identifier: string,
+    definition: string,
+): LobsterSignature {
+    let signature: LobsterSignature;
+    const [def, ret] = definition.split(/ ?-> ?/);
+    const defmatch = def.match(/^(.+)\((.*)\)$/);
+    if (defmatch) {
+        const parameters = readParameters(defmatch[2]);
+        signature = {
+            name: defmatch[1],
+            parameters,
+            returns: ret
+                ? ret.replace(" ", "").replace(/[()]/g, "").split(",")
+                : undefined,
+        };
+    } else {
+        signature = {
+            name: identifier,
+            type: def,
+        };
+    }
+    return signature;
 }
 
 export async function queryDefinition(
-	settings: LobsterSettings,
-	file: string,
-	line: integer,
-	identifier: string,
-	...args: string[]
+    settings: LobsterSettings,
+    file: string,
+    line: integer,
+    identifier: string,
+    ...args: string[]
 ): Promise<QueryDefinitionResult> {
-	function parseOutput(input: string): QueryDefinitionResult {
-		if (input.length == 0) return {};
+    function parseOutput(input: string): QueryDefinitionResult {
+        if (input.length == 0) return {};
 
-		let declartionLocation: LobsterLocation | undefined;
-		let signature: LobsterSignature | undefined;
+        let declartionLocation: LobsterLocation | undefined;
+        let signature: LobsterSignature | undefined;
 
-		const queryLocationB = input.indexOf('query_location');
-		if (queryLocationB != -1) {
-			const queryLocationE = input.substring(queryLocationB).indexOf('\n');
-			const sub = input.substring(queryLocationB, queryLocationE);
-			const match = sub.match(/^query_location: (.+) (\d+) (.+)?/);
+        const queryLocationB = input.indexOf("query_location");
+        if (queryLocationB != -1) {
+            const sub = input.substring(queryLocationB).split("\n")[0];
+            const match = sub.match(/^query_location: (.+) (\d+) (.+)?/);
 
-			if (!match) throw new Error("Invalid output from lobster: " + sub);
+            if (!match) {
+                console.error("Invalid query_location output from lobster: " + sub);
+            } else {
+                declartionLocation = {
+                    file: match[1].trim(),
+                    line: parseInt(match[2]) - 1, // Its zero based
+                };
+                if (match[3]) {
+                    signature = parseDefinition(identifier, match[3]);
+                }
+            }
+        }
 
-			declartionLocation = {
-				file: match[1].trim(),
-				line: parseInt(match[2]) - 1 // Its zero based
-			};
+        const querySignatureB = input.indexOf("query_signature");
+        if (querySignatureB != -1) {
+            const sub = input.substring(querySignatureB).split("\n")[0];
+            const match = sub.match(/^query_signature: (.*)/);
 
-			if (match[3]) {
-				const [def, ret] = match[3].split("->");
-				const defmatch = def.match(/^(.+)\((.*)\)$/)
-				if (defmatch) {
-					const parameters = readParameters(defmatch[2]);
-					signature = {
-						name: defmatch[1],
-						parameters,
-						returns: ret ? ret.replace(" ", "").replace(/[()]/g, "").split(",") : undefined
-					};
-				} else {
-					signature = {
-						name: identifier,
-						type: def
-					};
-				}
-			}
-		}
+            if (!match) {
+                console.error("Invalid query_signature output from lobster: " + sub);
+            } else {
+                signature = parseDefinition(identifier, match[1]);
+            }
+        }
 
-		const querySignatureB = input.indexOf('query_signature');
-		if (querySignatureB != -1) {
-			const querySignatureE = input.substring(querySignatureB).indexOf('\n');
-			const sub = input.substring(querySignatureB, querySignatureE);
-			const match = sub.match(/^query_signature: ([^)]+)\(([^)]*)\)(?:->\(([^)]+)\))?/);
+        return {
+            declartionLocation,
+            signature,
+        };
+    }
 
-			if (!match) throw new Error("Invalid output from lobster: " + sub);
+    const fileName = file.split(/\\|\//).pop();
+    if (!fileName) throw new Error("Invalid file name");
 
-			signature = {
-				name: match[1].trim(),
-				parameters: readParameters(match[2].trim()),
-				returns: match[3] ? match[3].replace(" ", "").replace(/[()]/g, "").split(",") : undefined
-			};
-		}
-
-		return {
-			declartionLocation,
-			signature
-		};
-	}
-
-
-	const fileName = file.split(/\\|\//).pop();
-	if (!fileName) throw new Error("Invalid file name");
-
-	return new Promise(back => callLobster(
-		settings,
-		i => back(parseOutput(i)),
-		file,
-		'--query', 'definition', fileName, (line + 1).toString(), identifier,
-		...args));
+    return new Promise((back) =>
+        callLobster(
+            settings,
+            (i) => back(parseOutput(i)),
+            file,
+            "--query",
+            "definition",
+            fileName,
+            (line + 1).toString(),
+            identifier,
+            ...args,
+        ),
+    );
 }
 
 function readParameters(input: string): LobsterSignatureParameter[] {
-	const parameters = input == '' ? [] : input.split(',')
-		.map(i => i.trim().match(/^(.+):(.+)$/) || [])
-		.map(i => ({ name: i[1], type: i[2] }));
+    const parameters = input == '' ? [] : input.split(',')
+        .map(i => i.trim().match(/^(.+):(.+)$/) || [])
+        .map(i => ({ name: i[1], type: i[2] }));
 
-	if (parameters.some(i => i.name == undefined || i.type == undefined))
-		throw new Error("Invalid output from lobster: " + input);
+    if (parameters.some(i => i.name == undefined || i.type == undefined))
+        throw new Error("Invalid output from lobster: " + input);
 
-	return parameters;
+    return parameters;
 }

--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -48,7 +48,7 @@ SlabAlloc *g_current_slaballoc;
             return g_current_slaballoc->dealloc_small(ptr); \
         }
 #else
-    #define USE_CURRENT_SLABALLOCATOR 
+    #define USE_CURRENT_SLABALLOCATOR
 #endif
 
 struct Ident : Named {
@@ -631,7 +631,7 @@ struct SymbolTable {
         for (auto tv  : typevars)         delete tv;
         for (auto su  : specudts)         delete su;
     }
-    
+
     bool MaybeNameSpace(string_view name) {
         return !current_namespace.empty() && name.find(".") == name.npos;
     }
@@ -1380,6 +1380,14 @@ inline string Signature(const NativeFun &nf) {
         FormatArg(r, arg.name, i, arg.type);
     }
     r += ")";
+    if (nf.retvals.size() > 0){
+        r += "->(";
+        for (auto [i, retval] : enumerate(nf.retvals)) {
+            if (i) r += ", ";
+            r += TypeName(retval.type);
+        }
+        r += ")";
+    }
     return r;
 }
 

--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -1379,12 +1379,11 @@ inline string Signature(const NativeFun &nf) {
     }
     r += ")";
     if (nf.retvals.size() > 0) {
-        r += "->(";
+        r += " -> ";
         for (auto [i, retval] : enumerate(nf.retvals)) {
             if (i) r += ", ";
             r += TypeName(retval.type);
         }
-        r += ")";
     }
     return r;
 }

--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -1380,7 +1380,7 @@ inline string Signature(const NativeFun &nf) {
         FormatArg(r, arg.name, i, arg.type);
     }
     r += ")";
-    if (nf.retvals.size() > 0){
+    if (nf.retvals.size() > 0) {
         r += "->(";
         for (auto [i, retval] : enumerate(nf.retvals)) {
             if (i) r += ", ";


### PR DESCRIPTION
Print builtin function returns in format
`funcname(param: type) -> (typeA, typeB)`

also fixes lsp crash on lookup for user function (was failed to parse returns)

![image](https://github.com/user-attachments/assets/ae0220f1-bca4-41c5-a3e5-69b9059118f1)
(above highlight is somewhat broken, but I didn't touch it)
![image](https://github.com/user-attachments/assets/8de52dff-06e4-4834-a257-843ab079a411)