### PR TITLE
Parse function signature with untyped parameter

### DIFF
--- a/dev/lsp/src/lobster.ts
+++ b/dev/lsp/src/lobster.ts
@@ -252,8 +252,8 @@ export async function queryDefinition(
 
 function readParameters(input: string): LobsterSignatureParameter[] {
     const parameters = input == '' ? [] : input.split(',')
-        .map(i => i.trim().match(/^(.+):(.+)$/) || [])
-        .map(i => ({ name: i[1], type: i[2] }));
+        .map(i => i.trim().match(/^([^:]+)(?::(.+))?$/) || [])
+        .map(i => ({ name: i[1], type: i[2] || "any" }));
 
     if (parameters.some(i => i.name == undefined || i.type == undefined))
         throw new Error("Invalid output from lobster: " + input);


### PR DESCRIPTION
Fixes lsp crash when parsing functions accepts parameter of any type ( like lobster_value_to_binary )
See also
https://github.com/aardappel/lobster/blob/a7b921a4f3fd4d661bb05a84a218cae5047cd93f/dev/src/lobster/idents.h#L1365C1-L1372C2