### PR TITLE
update docs

### DIFF
--- a/docs/implementation.html
+++ b/docs/implementation.html
@@ -256,7 +256,7 @@ replaced entirely by functions that use a different rendering system.
 You can turn Lobster into a console-only language in one step by simply
 removing the engine folder from the project.</p></li>
 </ul>
-<p>You can always run Lobster with the <code>-r</code> option to get an
+<p>You can always run Lobster with the <code>--gen-builtins-html</code> option to get an
 overview of all functions currently added to the system (the current
 list is <a href="builtin_functions_reference.html">here</a>). To
 add/remove functionality is generally as easy as adding/removing the

--- a/docs/lsp.html
+++ b/docs/lsp.html
@@ -40,6 +40,6 @@ editor/IDE</h2>
 IDE. See your IDE/editors documentation on how to integrate this. PRs
 are always welcome.</p>
 <p>You compile the LSP to a final js file to be execute by node with
-<code>npm webpack</code>.</p>
+<code>npm run webpack</code>.</p>
 </body>
 </html>


### PR DESCRIPTION
There's also a character missing (a backslash?) after or https://github.com/aardappel/lobster/blob/fa9a34e159735d81790e98a2e7d8efe4657730b7/docs/command_line_usage.html#L147