### PR TITLE
Fix hovered words detection. Now if you hover foo.bar.bas over bar it…

### DIFF
--- a/dev/lsp/src/utils.ts
+++ b/dev/lsp/src/utils.ts
@@ -2,8 +2,8 @@ import { MarkupContent, MarkupKind } from 'vscode-languageserver';
 import { LobsterSignature } from './lobster';
 
 export function getWordOnCursor(text: string, character: number): [string | null, number] {
-	const part1 = text.substring(0, character).match(/[a-zA-Z0-9-_\\.]+$/);
-	const part2 = text.substring(character).match(/^[a-zA-Z0-9-_\\.]+/);
+	const part1 = text.substring(0, character).match(/[a-zA-Z0-9_\\.]+$/);
+	const part2 = text.substring(character).match(/^[a-zA-Z0-9_]+/);
 
 	if (!part1 && !part2) return [null, 0];
 	return [


### PR DESCRIPTION
… produces foo.bar instead of foo.bar.bas

Here cursor is over `foo`
![image](https://github.com/user-attachments/assets/6ab5f5ee-9395-461c-aa95-d0df6e2ca5bd)
