### PR TITLE
Fixed no type for freshly declared variable and nested typecheck

### DIFF
--- a/dev/src/compiler.cpp
+++ b/dev/src/compiler.cpp
@@ -336,8 +336,8 @@ string GetBuiltinDoc(NativeRegistry &nfr, bool group_subsystem, string (&doc_tag
         }
         s += is_first_row ? doc_tags[Tags::FirstRow][0] : doc_tags[Tags::Row][0];
         if (!group_subsystem) {
-            s += cat(doc_tags[Tags::Subsystem][0], 
-                    nfr.subsystems[nf->subsystemid], 
+            s += cat(doc_tags[Tags::Subsystem][0],
+                    nfr.subsystems[nf->subsystemid],
                     doc_tags[Tags::Subsystem][1]);
         }
         s += cat(doc_tags[Tags::Name][0], nf->name, doc_tags[Tags::Name][1]);
@@ -405,7 +405,7 @@ string GetBuiltinDoc(NativeRegistry &nfr, bool group_subsystem, string (&doc_tag
 
 void DumpBuiltinDoc(NativeRegistry &nfr, bool group_subsystem) {
     string html_tags[16][2] = {
-    /* Doc          */  {"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n"                                                        
+    /* Doc          */  {"<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n"
     /*              */   "<html>\n<head>\n<title>lobster builtin function reference</title>\n"
     /*              */   "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n"
     /*              */   "<style type=\"text/css\">"
@@ -434,7 +434,7 @@ void DumpBuiltinDoc(NativeRegistry &nfr, bool group_subsystem) {
 }
 
 void DumpBuiltinDocJson(NativeRegistry &nfr) {
-    string json_tags[16][2] = { 
+    string json_tags[16][2] = {
     /* Doc          */ {"", ""},
     /* Table        */ {"[", "]"},
     /* Row          */ {",\n{", "}"},
@@ -488,7 +488,9 @@ void Compile(NativeRegistry &nfr, string_view fn, string_view stringsource, stri
     parser.Parse();
     if (query) PrepQuery(*query, filenames);
     TypeChecker tc(parser, st, return_value, query, full_error);
-    if (query) tc.ProcessQuery();  // Failed to find location during type checking.
+    if (query) { // Failed to find location during type checking.
+        if(!tc.ProcessQuery()) THROW_OR_ABORT("query_unknown_ident: " + query->iden);
+    }
     if (lex.num_errors) THROW_OR_ABORT("errors encountered, aborting");
     tc.Stats(filenames);
     // Optimizer is not optional, must always run, since TypeChecker and CodeGen

--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -804,7 +804,7 @@ struct SymbolTable {
         defsubfunctionstack.push_back(sf);
     }
 
-    void    ister(const Enum *e, unordered_map<string_view, Enum *> &dict) {
+    void Unregister(const Enum *e, unordered_map<string_view, Enum *> &dict) {
         auto it = dict.find(e->name);
         if (it != dict.end()) {
             for (auto &ev : e->vals) {
@@ -903,6 +903,11 @@ struct SymbolTable {
         }
         auto uit = gudts.find(name);
         if (uit != gudts.end()) return uit->second;
+        for (auto gudt = gudttable.rbegin(); gudt != gudttable.rend(); ++gudt) {
+            if((*gudt)->name == name) {
+                return *gudt;
+            }
+        }
         return nullptr;
     }
 

--- a/dev/src/lobster/parser.h
+++ b/dev/src/lobster/parser.h
@@ -131,7 +131,7 @@ struct Parser {
             } else if (auto sr = Is<GUDTRef>(def)) {
                 if (sr->gudt->predeclaration)
                     Error("pre-declared struct ", Q(sr->gudt->name), " never defined");
-                Unregister(sr->gudt, st.gudts);
+                //Unregister(sr->gudt, st.gudts); //Breaks detecting struct and fields
             } else if (auto sr = Is<UDTRef>(def)) {
                 Unregister(sr->udt, st.udts);
             } else if (auto fr = Is<FunRef>(def)) {
@@ -565,7 +565,7 @@ struct Parser {
                 if (was_predeclaration) {
                     udt = gudt->first;
                     assert(udt && !udt->next);
-                } else { 
+                } else {
                     udt = st.MakeSpecialization(*gudt, sname, false, false);
                 }
             }

--- a/dev/src/lobster/parser.h
+++ b/dev/src/lobster/parser.h
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "lobster/idents.h"
+#include "lobster/lex.h"
+#include "lobster/natreg.h"
 namespace lobster {
 
 struct Parser {
@@ -131,7 +134,7 @@ struct Parser {
             } else if (auto sr = Is<GUDTRef>(def)) {
                 if (sr->gudt->predeclaration)
                     Error("pre-declared struct ", Q(sr->gudt->name), " never defined");
-                //Unregister(sr->gudt, st.gudts); //Breaks detecting struct and fields
+                Unregister(sr->gudt, st.gudts); //Breaks detecting struct and fields
             } else if (auto sr = Is<UDTRef>(def)) {
                 Unregister(sr->udt, st.udts);
             } else if (auto fr = Is<FunRef>(def)) {

--- a/dev/src/lobster/typecheck.h
+++ b/dev/src/lobster/typecheck.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "idents.h"
 namespace lobster {
 
 struct LValContext {
@@ -2329,9 +2330,8 @@ struct TypeChecker {
             }
         }
     }
-    std::optional<TypeRef> FindVarType(string_view ident, auto sf) {
-        auto desf = *sf;
-        for (auto &vars : {desf->args, desf->locals, desf->freevars}) {
+    std::optional<TypeRef> FindVarType(string_view ident, SubFunction *sf) {
+        for (auto &vars : {sf->args, sf->locals, sf->freevars}) {
             for (auto &var : vars) {
                 if (var.sid->id->name == ident) {
                     return var.sid->type;
@@ -2341,14 +2341,14 @@ struct TypeChecker {
         return std::nullopt;
     }
 
-    bool ProcessDefinition(GUDT *parent, string full_iden, auto sf) {
+    bool ProcessDefinition(GUDT *parent, string full_iden, SubFunction **sf) {
         int pos = full_iden.find(".");
         bool got_pos = pos != std::string::npos;
         string ident = full_iden;
         if (got_pos) {
             ident = full_iden.substr(0, pos);
             //Possible a class or a struct name
-            auto ident_type = FindVarType(ident, sf);
+            auto ident_type = FindVarType(ident, *sf);
             if (ident_type.has_value()) {
                 ident = TypeName(ident_type.value());
             }

--- a/dev/src/lobster/typecheck.h
+++ b/dev/src/lobster/typecheck.h
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "idents.h"
+#include "lobster/node.h"
+#include "lobster/stdafx.h"
 namespace lobster {
 
 struct LValContext {
@@ -2262,7 +2264,9 @@ struct TypeChecker {
         AdjustLifetime(n, recip, idents);
         // Check for queries.
         //TODO: instead of n->line.line>query->qloc.line check if this is the last node on the line query->qloc.line
-        if (query && n->line.line>query->qloc.line && n->line.fileidx==query->qloc.fileidx) ProcessQuery();
+        if (query && n->line.line>query->qloc.line && n->line.fileidx==query->qloc.fileidx) {
+            ProcessQuery();
+        }
     }
 
     // TODO: Can't do this transform ahead of time, since it often depends upon the input args.
@@ -2342,7 +2346,7 @@ struct TypeChecker {
     }
 
     bool ProcessDefinition(GUDT *parent, string full_iden, SubFunction **sf) {
-        int pos = full_iden.find(".");
+        int pos = full_iden.find('.');
         bool got_pos = pos != std::string::npos;
         string ident = full_iden;
         if (got_pos) {


### PR DESCRIPTION
### Strong review needed - contains a lot of doubtful changes in code in doubtful language.

_especially look at parser.h:134_

- Fixed no type for freshly declared variable
- Nested typecheck for foo.bar.bas()
- Tastes better with #347

alpha is just declared but recognized correctly
![image](https://github.com/user-attachments/assets/3c12b18c-9675-461a-9d06-89d438f82d34)

method from Beta class (before there would be a collision with Alpha)
![image](https://github.com/user-attachments/assets/8d8ba076-75b2-4225-a15e-a70e8e99d93a)

Detected type of nested class
![image](https://github.com/user-attachments/assets/a24e611c-6046-40d3-a2fb-f332bff9189d)

and its method
![image](https://github.com/user-attachments/assets/9e3f3c9d-5b45-4991-88a9-5b6eebda3809)

field also detected
![image](https://github.com/user-attachments/assets/5ef4d8a7-5b47-4ed4-8cfd-4ed5fa4f6413)
