### PR TITLE
Fixes queries for lsp

### DIFF
--- a/dev/src/compiler.cpp
+++ b/dev/src/compiler.cpp
@@ -488,7 +488,9 @@ void Compile(NativeRegistry &nfr, string_view fn, string_view stringsource, stri
     parser.Parse();
     if (query) PrepQuery(*query, filenames);
     TypeChecker tc(parser, st, return_value, query, full_error);
-    if (query) tc.ProcessQuery();  // Failed to find location during type checking.
+    if (query) { // Failed to find location during type checking.
+        if(!tc.ProcessQuery()) THROW_OR_ABORT("query_unknown_ident: " + query->iden);
+    }
     if (lex.num_errors) THROW_OR_ABORT("errors encountered, aborting");
     tc.Stats(filenames);
     // Optimizer is not optional, must always run, since TypeChecker and CodeGen

--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -903,6 +903,12 @@ struct SymbolTable {
         }
         auto uit = gudts.find(name);
         if (uit != gudts.end()) return uit->second;
+        return nullptr;
+    }
+    GUDT *LookupStructQuery(string_view name) {
+        GUDT* res = LookupStruct(name);
+        if(res) return res;
+        //Try to search out of scope when doing query
         for (auto gudt = gudttable.rbegin(); gudt != gudttable.rend(); ++gudt) {
             if((*gudt)->name == name) {
                 return *gudt;

--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -903,6 +903,11 @@ struct SymbolTable {
         }
         auto uit = gudts.find(name);
         if (uit != gudts.end()) return uit->second;
+        for (auto gudt = gudttable.rbegin(); gudt != gudttable.rend(); ++gudt) {
+            if((*gudt)->name == name) {
+                return *gudt;
+            }
+        }
         return nullptr;
     }
 

--- a/dev/src/lobster/typecheck.h
+++ b/dev/src/lobster/typecheck.h
@@ -2333,15 +2333,15 @@ struct TypeChecker {
             }
         }
     }
-    std::optional<TypeRef> FindVarType(string_view ident, SubFunction *sf) {
+    TypeRef FindVarType(string_view ident, SubFunction *sf) {
         for (auto &vars : {sf->args, sf->locals, sf->freevars}) {
             for (auto &var : vars) {
-                if (var.sid->id->name == ident) {
+                if (var.sid->id->name == ident && !var.sid->type.Null()) {
                     return var.sid->type;
                 }
             }
         }
-        return std::nullopt;
+        return TypeRef(nullptr);
     }
 
     bool ProcessDefinition(GUDT *parent, string full_iden, SubFunction **sf) {
@@ -2352,8 +2352,8 @@ struct TypeChecker {
             ident = full_iden.substr(0, pos);
             //Possible a class or a struct name
             auto ident_type = FindVarType(ident, *sf);
-            if (ident_type.has_value()) {
-                ident = TypeName(ident_type.value());
+            if (!ident_type.Null()) {
+                ident = TypeName(ident_type);
             }
         }
         auto new_parent_struct = st.LookupStructQuery(ident);

--- a/dev/src/lobster/typecheck.h
+++ b/dev/src/lobster/typecheck.h
@@ -2363,7 +2363,7 @@ struct TypeChecker {
         }
 
         // FIXME: may not work when namespaces are involved.
-        auto f = st.FindFunction(ident);
+        auto f = st.FindFunction(full_iden);
         if (f) {
             auto ov = f->overloads[0];
             if(parent) { //Try to find method of parent class with same name
@@ -2378,7 +2378,7 @@ struct TypeChecker {
                 LocationQuery(ov->gbody->line, ov->sf ? Signature(*ov->sf) : "");
             }
         }
-        auto fld = st.FieldUse(ident);
+        auto fld = st.FieldUse(full_iden);
         if (fld && parent) {
             // To know what this belongs to, would need to find the object it belongs to.
             // For now, simply see if we can find any class that has this field.
@@ -2391,7 +2391,7 @@ struct TypeChecker {
                 LocationQuery(parent->fields[fi].defined_in, TypeName(parent->fields[fi].giventype));
             }
         }
-        auto nf = parser.natreg.FindNative(ident);
+        auto nf = parser.natreg.FindNative(full_iden);
         if (nf) {
             // This doesn't have a source code location, so output a signature the IDE can display.
             THROW_OR_ABORT("query_signature: " + Signature(*nf));

--- a/dev/src/lobster/typecheck.h
+++ b/dev/src/lobster/typecheck.h
@@ -2345,7 +2345,7 @@ struct TypeChecker {
     }
 
     bool ProcessDefinition(GUDT *parent, string full_iden, SubFunction **sf) {
-        int pos = full_iden.find('.');
+        size_t pos = full_iden.find('.');
         bool got_pos = pos != std::string::npos;
         string ident = full_iden;
         if (got_pos) {

--- a/dev/src/lobster/typecheck.h
+++ b/dev/src/lobster/typecheck.h
@@ -2356,7 +2356,7 @@ struct TypeChecker {
                 ident = TypeName(ident_type.value());
             }
         }
-        auto new_parent_struct = st.LookupStruct(ident);
+        auto new_parent_struct = st.LookupStructQuery(ident);
 
         if (new_parent_struct && !got_pos){ //Just class instance
             LocationQuery(new_parent_struct->line, Signature(*new_parent_struct));

--- a/dev/src/lobster/typecheck.h
+++ b/dev/src/lobster/typecheck.h
@@ -2384,7 +2384,7 @@ struct TypeChecker {
             // For now, simply see if we can find any class that has this field.
             int fi = parent->Has(fld);
             if (fi >= 0) {
-                auto struct_type = st.LookupStruct(TypeName(parent->fields[fi].giventype));
+                auto struct_type = st.LookupStructQuery(TypeName(parent->fields[fi].giventype));
                 if (got_pos) { //Go further with detected struct as a parent
                     ProcessDefinition(struct_type, full_iden.substr(pos+1), sf);
                 }


### PR DESCRIPTION
- Fixed no type for freshly declared variable
- Nested typecheck for foo.bar.bas() constructions

This one is much better than #348 
Now there is only two possible breaking changes:
1. `LookupStruct` now search inside `gudttable`
2. `ProcessQuery` is now returns `bool`. Otherwise the call to `ProcessQuery` in `Compile` was always unreachable because of the `THROW_OR_ABORT` call in the end of `ProcessQuery` . So now it is required to call it manually after `ProcessQuery` returns `false`.

Also no more annoying spaces, etc. But I kept `ProcessDefinition` as a separate function because of its recursive nature.


still may get some collisions (below it should be `zk.d: int`)
![image](https://github.com/user-attachments/assets/814fc87e-4173-4d71-9e58-861bee97d988)