### PR TITLE
Return from validateDocument if no diagnostics

### DIFF
--- a/dev/lsp/src/document.ts
+++ b/dev/lsp/src/document.ts
@@ -132,9 +132,9 @@ export class LobsterDocument implements TextDocument {
 		return join;
 	}
 
-	public async parse(lsp: LSPInstance|undefined): Promise<Diagnostic[]> {
+	public async parse(lsp: LSPInstance|undefined): Promise<Diagnostic[] | null> {
         if(lsp == undefined) { //Not ready
-            return []
+            return null
         }
 		const settings = await lsp.getDocumentSettings(this._uri);
 		if (lsp.errored()) return [];

--- a/dev/lsp/src/lsp.ts
+++ b/dev/lsp/src/lsp.ts
@@ -33,6 +33,7 @@ export class LSPInstance {
     constructor(connection: Connection, tempDir: string) {
         this.tempDir = tempDir;
         this.connection = connection;
+        this.documents.listen(this.connection);
 
         this.documents.onDidClose(e => {
             this.documentSettings.delete(URI.parse(e.document.uri));
@@ -42,7 +43,6 @@ export class LSPInstance {
             this.validateDocument(change.document);
         });
 
-        this.documents.listen(this.connection);
     }
 
     readConfiguration(uri: URI): Promise<LobsterSettings> {
@@ -102,6 +102,7 @@ export class LSPInstance {
     async validateDocument(document: LobsterDocument) {
         const noErrBefore = document.state === LobsterDocumentState.NoErrors;
         const diagnostics = await document.parse(this);
+        if (!diagnostics) return;
         if (!noErrBefore || diagnostics.length > 0) {
             this.connection.sendDiagnostics({
                 uri: document.uri,


### PR DESCRIPTION
This fixes LSP startup error when cursor over editor provokes querying lsp before it was actually initialized