### PR TITLE
Make member function of string_view_nt const

### DIFF
--- a/dev/src/lobster/string_tools.h
+++ b/dev/src/lobster/string_tools.h
@@ -33,7 +33,7 @@ struct string_view_nt {
     size_t size() const { return sv.size(); }
     const char *data() const { return sv.data(); }
 
-    const char *c_str() {
+    const char *c_str() const {
         check_null_terminated();  // Catch appends to parent buffer since construction.
         return sv.data();
     }


### PR DESCRIPTION
As string_view_nt should give read-only access, the member function `c_str()` should be marked as such.