### PR TITLE
modify syntax highlighting patterns for escaped characters in strings

### DIFF
--- a/dev/vscode-ext/syntaxes/lobster.tmLanguage.json
+++ b/dev/vscode-ext/syntaxes/lobster.tmLanguage.json
@@ -184,16 +184,24 @@
         {
           "name": "string.quoted.triple.lobster",
           "begin": "\"{3}",
-          "end": "\"{3}"
+          "end": "\"{3}",
+          "patterns": [
+            {
+              "name": "constant.character.escape.lobster",
+              "match": "(\\\\n|\\\\t|\\\\r|\\\\\"|\\\\'|\\\\x\\h{2}|\\\\w|\\\\)"
+            }
+          ]
         },
         {
           "name": "string.quoted.double.lobster",
           "begin": "\"",
-          "end": "\""
-        },
-        {
-          "name": "constant.character.escape.lobster",
-          "match": "'(\\\\n|\\\\t|\\\\r|\\\\\"|\\\\'|\\\\x\\h{2}|\\w|\\\\|)'"
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.lobster",
+              "match": "(\\\\n|\\\\t|\\\\r|\\\\\"|\\\\'|\\\\x\\h{2}|\\\\w|\\\\)"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
The pattern for escaped characters was like this:
```regex
'(\\\\n|\\\\t|\\\\r|\\\\\"|\\\\'|\\\\x\\h{2}|\\w|\\\\|)'
```

Now is like this:
```regex
(\\\\n|\\\\t|\\\\r|\\\\\"|\\\\'|\\\\x\\h{2}|\\\\w|\\\\)
```
Previously, this happened: (`tests/misctest.lobster`, line 69)

<img width="1155" height="933" alt="image" src="https://github.com/user-attachments/assets/7e94e9e0-403e-4ea9-90ca-ecacc1b994a3" />

With the new regex, and putting it as a subpattern of the string pattern, it looks like this:

<img width="1155" height="933" alt="image" src="https://github.com/user-attachments/assets/7f46d023-7473-406d-9afc-2692f531187b" />

I think I got all the existing cases right, but these things are tricky. Please let me know if I missed something.