### PR TITLE
Steam Multiplayer would endlessly hang waiting for the players because local_ident was never ready 

### DIFF
--- a/samples/shooter_tutorial/tut_net.lobster
+++ b/samples/shooter_tutorial/tut_net.lobster
@@ -150,7 +150,7 @@ def renderpointytriangle(pos, dir):
     gl.translate pos:
         gl.rotate_z dir:
             gl.polygon([ float2 { -0.5, 0.5 }, float2_x, float2 { -0.5, -0.5 } ])
-
+local_ident = steam.net_identity()
 while gl.frame():
     // Update networking
     steam.update()


### PR DESCRIPTION
when testing this program multiplayer did not work
after some debugging I found that
local_ident was never initialized with the local identity

I initialize the local_ident at the top of the while loop so it gets initialized upfront
making the assumption that any special case most likely sets it explicitly after that point

I did not check every branch of code to guarantee correctness, it works for the normal friends lobby

the issue is specifically in this case:
```
                    case GS_HOST_WAITING_FOR_PEERS:
                        im.text("Waiting for peers...")
                        let ready = all(map(players): has_peer(_.ident))
                        guard ready
                        // Let all peers know that the game is starting
                        let peers_copy = copy(peers)
                        peers_copy.push(local_ident)
                        send(m_start_game { peers_copy })
                        game_state = GS_START_GAME
```

ready would get set to [false, true]
false being local_ident
 ```py
 let ready = all(map(players): has_peer(_.ident))
 // local_ident was never set so it was empty always returning false     
 def has_peer(id):
        return id == local_ident or (find(peers): _ == id) != -1
```