### PR TITLE
StructAssign did not pass Line info to lex.error FIXED

### DIFF
--- a/dev/src/lobster/idents.h
+++ b/dev/src/lobster/idents.h
@@ -87,9 +87,9 @@ struct Ident : Named {
         if (constant) lex.Error("variable " + name + " is constant");
     }
 
-    void StructAssign(Lex &lex) {
+    void StructAssign(Lex &lex,Line *ln = nullptr) {
         struct_field_assign = true;
-        if (constant) lex.Error("variable " + name + " is a constant struct, cannot modify its fields");
+        if (constant) lex.Error("variable " + name + " is a constant struct, cannot modify its fields", ln);
     }
 
     Ident *Read() {

--- a/dev/src/lobster/typecheck.h
+++ b/dev/src/lobster/typecheck.h
@@ -2152,7 +2152,7 @@ struct TypeChecker {
             }
             if (auto idr = Is<IdentRef>(fn)) {
                 if (IsStruct(idr->exptype->t)) {
-                    idr->sid->id->StructAssign(parser.lex);
+                    idr->sid->id->StructAssign(parser.lex,&fn->line);
                 }
             }
         }


### PR DESCRIPTION
Fixed this issue
https://github.com/aardappel/lobster/issues/393

StructAssign calls lex.Error with an error message but with no Line to pass the line information

seems pretty straight forward but I dont know this codebase well just trying to learn it better and hopefully be helpful

after testing it it gave the correct answers for the test cases in issue 393


here is the code for lex.Error for context
```cpp
// line 729 lex.h
    [[noreturn]] void Error(string_view msg, const Line *ln = nullptr) {
        num_errors++;
        auto err = Location(ln ? *ln : *this) + ": error: " + msg;
        if (!ln) {
            auto begin = prevtokenstart;
            auto end = prevtokenend;
            while (begin > source.get()->c_str() && *(begin - 1) != '\n') begin--;
            while (*end && *end != '\n' && *end != '\r') end++;
            if (end - begin > 0) {
                append(err, "\nin: ", string_view(begin, end - begin));
                if (prevtokenend - prevtokenstart > 0) {
                    append(err, "\nat: ");
                    for (; begin < prevtokenstart; begin++) err.push_back(' ');
                    for (; begin < prevtokenend; begin++) err.push_back('^');
                }
            }
        }
        //LOG_DEBUG(err);
        THROW_OR_ABORT(err);
    }

```
