### PR TITLE
Fix for Error at the wrong line

### DIFF
--- a/dev/src/lobster/parser.h
+++ b/dev/src/lobster/parser.h
@@ -47,10 +47,6 @@ struct Parser {
         lex.Error(cat(args...), what ? &what->line : nullptr);
     }
 
-    template<typename... Ts> void ErrorAtLine(const Line *line, const Ts &...args) {
-        lex.Error(cat(args...), line);
-    }
-
     template<typename... Ts> void Warn(const Ts &...args) {
         lex.Warn(cat(args...), nullptr);
     }
@@ -155,7 +151,7 @@ struct Parser {
                         (id->name[0] != '_' || d->tsids.size() == 1))
                         Warn("unused variable ", Q(id->name));
                     if (id->predeclaration)
-                      ErrorAtLine(&id->line,"missing declaration for ", id->name);
+                      ErrorAt(d,"missing declaration for ", id->name);
                 }
             } else if (auto r = Is<Return>(def)) {
                 if (r != list->children.back())


### PR DESCRIPTION
https://github.com/aardappel/lobster/issues/398

its on line 154 in dev/src/lobster/parser.h
Error("missing declaration for ", id->name);
doesn't pass the line information
the alternative function ErrorAt accepts a Node and not an Ident

I created a similar template to ErrorAt that takes a Line
I could have done it similarly to ErrorAt and passed the Ident
but passing a Line is more generic

I pass the line by pointer because lex.Warn and lex.Error expect pointers
I tried it with passing by value it worked but for consistency sake I used a pointer



